### PR TITLE
Phase2 sprint4

### DIFF
--- a/Caddyfile.standalone
+++ b/Caddyfile.standalone
@@ -1,0 +1,18 @@
+# Standalone Caddyfile — self-signed TLS, no external dependencies.
+# Used by docker-compose.standalone.yml for quick local testing.
+
+{$SITE_HOST:localhost}:443, localhost:443 {
+	tls internal
+
+	handle /api/* {
+		reverse_proxy backend:8000
+	}
+
+	handle {
+		reverse_proxy hinotes-frontend:80
+	}
+}
+
+:80 {
+	redir https://{host_only}{uri} permanent
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A self-hosted web application for managing, transcribing, and summarizing audio 
 - **SSO / OIDC** — single sign-on via any OpenID Connect provider (Google, Microsoft Entra ID, Keycloak, Okta, Auth0, etc.), multiple providers simultaneously
 - **Collections & sharing** — organize transcriptions into collections, share with users or groups
 - **Dark mode** — system-aware theme with manual toggle, glass-morphism UI
-- **Fully dockerized** — Docker Compose with PostgreSQL, FastAPI, Vite/Nginx, and Caddy (HTTPS required for WebUSB)
+- **Fully dockerized** — Docker Compose with PostgreSQL, FastAPI, and Vite/Nginx — designed to sit behind an existing reverse proxy (Caddy, Nginx, Traefik, etc.) over a shared Docker network
 
 ## Architecture
 
@@ -30,39 +30,71 @@ A self-hosted web application for managing, transcribing, and summarizing audio 
 └──────┬───────┘                                        │
        │ HTTPS                                          │
 ┌──────▼───────┐       ┌──────────────┐                 │
-│    Caddy     │──────►│   FastAPI    │─────────────────┘
-│  (reverse    │       │   Backend    │
-│   proxy)     │       │              │───────► LLM API (chat/summaries)
-└──────────────┘       └──────┬───────┘
-                              │
-                       ┌──────▼───────┐
+│  Your reverse│──────►│   FastAPI    │─────────────────┘
+│  proxy       │       │   Backend    │
+│  (Caddy /    │       │              │───────► LLM API (chat/summaries)
+│   Nginx /    │       └──────┬───────┘
+│   Traefik)   │──────►┌──────▼───────┐
+└──────────────┘       │  React/Nginx │
+       ▲               │  Frontend    │
+       │               └──────────────┘
+ proxy-net                    │
+ (Docker network)      ┌──────▼───────┐
                        │  PostgreSQL  │
                        └──────────────┘
 ```
 
+OpenHiNotes does **not** bundle a reverse proxy. The `frontend` container joins an external Docker network (`proxy-net`) so your existing proxy can reach it by container name (`hinotes-frontend`). The `db` and `backend` containers are isolated on an internal network and are never exposed to the host.
+
 ---
 
-## Quick Start (Development)
+## Quick Start
 
 ### Prerequisites
 
 - Docker and Docker Compose
 - A [VoxHub](https://github.com/ghecko/VoxHub) server for transcription
-- Optionally, an OpenAI-compatible LLM endpoint (Ollama, LM Studio, OpenAI, etc.)
+- A reverse proxy (Caddy, Nginx, Traefik, etc.) serving HTTPS — **required for WebUSB**
+- An external Docker network named `proxy-net` that your reverse proxy already uses
 
-### Setup
+> **Why a separate reverse proxy?** WebUSB requires a secure context (HTTPS). OpenHiNotes is designed to sit behind whatever proxy you already run on your server, keeping the compose file simple and avoiding bundled certificate management.
+
+### 1. Create the shared network (once per host)
+
+```bash
+docker network create proxy-net
+```
+
+### 2. Configure and start
 
 ```bash
 git clone https://github.com/ghecko/OpenHiNotes.git
 cd OpenHiNotes
 
 cp .env.example .env
-# Edit .env — at minimum set VOXHUB_API_URL and LLM_API_URL
+# Edit .env — at minimum set VOXHUB_API_URL, LLM_API_URL, and SITE_HOST
 
-docker compose up --build
+docker compose up -d --build
 ```
 
-Open **https://localhost:8443** in your browser (accept the self-signed certificate). HTTPS is required for WebUSB.
+### 3. Point your reverse proxy at the frontend
+
+The frontend container is named `hinotes-frontend` and listens on port 80. Example Caddy block:
+
+```caddyfile
+hinotes.yourdomain.com {
+    handle /api/* {
+        reverse_proxy backend:8000
+    }
+    handle {
+        reverse_proxy hinotes-frontend:80
+    }
+}
+```
+
+> For Nginx or Traefik, route `/api/*` to the backend container on port 8000 and everything else to `hinotes-frontend:80`.
+
+Open your configured domain in a browser. HTTPS is required for WebUSB to function.
 
 Default admin credentials (override in `.env` before first startup):
 
@@ -77,7 +109,7 @@ Default admin credentials (override in `.env` before first startup):
 
 ### 1. Prepare the server
 
-Any Linux host with Docker and Docker Compose installed. The server must be reachable on ports 80 and 443.
+Any Linux host with Docker and Docker Compose installed. The server must be reachable on ports 80 and 443 via your reverse proxy.
 
 ### 2. Configure environment
 
@@ -104,30 +136,29 @@ Fill in every variable — pay special attention to the ones marked **required**
 
 > **Security note**: `VOICE_EMBEDDING_KEY` and `OIDC_ENCRYPTION_KEY` default to a derivation of `SECRET_KEY` if left empty. Set them explicitly in production so that rotating `SECRET_KEY` doesn't break encrypted data.
 
-### 3. Configure TLS
+### 3. Configure your reverse proxy
 
-The production Caddyfile (`Caddyfile.prod`) uses `tls internal` (self-signed). For a real domain with automatic Let's Encrypt certificates, replace that block with your domain:
+Point your existing proxy at the `hinotes-frontend` container (port 80) for the UI and `backend` container (port 8000) for `/api/*`. Both are reachable via the shared `proxy-net` Docker network.
+
+Example Caddy block for production:
 
 ```caddyfile
 hinotes.company.com {
-    # API routes → backend
     handle /api/* {
         reverse_proxy backend:8000
     }
-
-    # Static frontend
     handle {
-        reverse_proxy frontend:80
+        reverse_proxy hinotes-frontend:80
     }
 }
 ```
 
-Caddy will automatically obtain and renew a Let's Encrypt certificate when given a real domain name.
+If your proxy runs outside Docker, expose the frontend port in `docker-compose.yml` and proxy to `localhost:<port>` instead.
 
 ### 4. Launch
 
 ```bash
-docker compose -f docker-compose.prod.yml up -d --build
+docker compose up -d --build
 ```
 
 ### 5. First login

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ OpenHiNotes does **not** bundle a reverse proxy. The `frontend` container joins 
 
 ## Quick Start
 
+> **Just want to try it out?** See [docs/STANDALONE_QUICKSTART.md](docs/STANDALONE_QUICKSTART.md) for a one-command setup with a bundled self-signed Caddy — no external reverse proxy needed.
+
+The instructions below assume you already run a reverse proxy on your server (Caddy, Nginx, Traefik, etc.) and want to integrate OpenHiNotes into it.
+
 ### Prerequisites
 
 - Docker and Docker Compose

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,7 @@ from app.routers import groups as groups_router
 from app.routers import shares as shares_router
 from app.routers import voice_profiles as voice_profiles_router
 from app.routers import oidc as oidc_router
+from app.routers import export as export_router
 from app.models.template import SummaryTemplate
 from app.default_templates import DEFAULT_TEMPLATES
 import logging
@@ -58,6 +59,7 @@ app.include_router(shares_router.router, prefix="/api")
 app.include_router(voice_profiles_router.router, prefix="/api")
 app.include_router(oidc_router.public_router, prefix="/api")
 app.include_router(oidc_router.admin_router, prefix="/api")
+app.include_router(export_router.router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/app/routers/export.py
+++ b/backend/app/routers/export.py
@@ -1,0 +1,99 @@
+"""Export router — GET /api/transcriptions/{id}/export?format=txt|srt|vtt|md|docx"""
+
+import uuid
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import Response
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.models.transcription import Transcription
+from app.models.summary import Summary
+from app.models.user import User, UserRole
+from app.models.resource_share import ResourceType
+from app.services.permissions import PermissionService
+
+router = APIRouter(tags=["export"])
+
+CONTENT_TYPES = {
+    "txt":  "text/plain; charset=utf-8",
+    "srt":  "text/plain; charset=utf-8",
+    "vtt":  "text/vtt; charset=utf-8",
+    "md":   "text/markdown; charset=utf-8",
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+
+
+@router.get("/transcriptions/{transcription_id}/export")
+async def export_transcription(
+    transcription_id: uuid.UUID,
+    format: str = Query(..., regex="^(txt|srt|vtt|md|docx)$"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Export a transcription in the requested format.
+
+    Formats:
+    - txt   — plain text with speaker labels and timestamps
+    - srt   — SubRip subtitles
+    - vtt   — WebVTT subtitles
+    - md    — Markdown document (includes summaries)
+    - docx  — Microsoft Word document (includes summaries)
+    """
+    # Load transcription
+    result = await db.execute(
+        select(Transcription).where(Transcription.id == transcription_id)
+    )
+    transcription = result.scalars().first()
+    if not transcription:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transcription not found")
+
+    # Access check — owner and admin always allowed; others need at least read share
+    if transcription.user_id != current_user.id and current_user.role != UserRole.admin:
+        has_access = await PermissionService.check_access(
+            db, current_user, ResourceType.transcription, transcription_id, required="read"
+        )
+        if not has_access:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    if transcription.status.value != "completed":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Transcription is not yet complete",
+        )
+
+    # Load summaries for rich formats
+    summaries = []
+    if format in ("md", "docx"):
+        s_result = await db.execute(
+            select(Summary)
+            .where(Summary.transcription_id == transcription_id)
+            .order_by(Summary.created_at.asc())
+        )
+        summaries = s_result.scalars().all()
+
+    # Generate export bytes
+    from app.services.export import export_txt, export_srt, export_vtt, export_md, export_docx
+
+    if format == "txt":
+        data = export_txt(transcription)
+    elif format == "srt":
+        data = export_srt(transcription)
+    elif format == "vtt":
+        data = export_vtt(transcription)
+    elif format == "md":
+        data = export_md(transcription, summaries)
+    else:  # docx
+        data = export_docx(transcription, summaries)
+
+    # Build safe download filename
+    raw_name = transcription.title or transcription.original_filename or str(transcription_id)
+    safe_name = "".join(c if c.isalnum() or c in "-_ ." else "_" for c in raw_name).rstrip(".")
+    filename = f"{safe_name}.{format}"
+
+    return Response(
+        content=data,
+        media_type=CONTENT_TYPES[format],
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/app/services/export.py
+++ b/backend/app/services/export.py
@@ -1,0 +1,338 @@
+"""Export service — generates transcription exports in various formats.
+
+Supported formats:
+  txt   — plain text with speaker labels and timestamps
+  srt   — SubRip subtitle format
+  vtt   — WebVTT subtitle format
+  md    — Markdown document
+  docx  — Microsoft Word document
+"""
+
+from __future__ import annotations
+
+import io
+import math
+from typing import Any, Optional
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _resolve_speaker(raw: str, speakers: dict[str, str]) -> str:
+    """Return human-readable speaker name, falling back to the raw label."""
+    return speakers.get(raw, raw) if speakers else raw
+
+
+def _seconds_to_hms(seconds: float) -> str:
+    """Convert seconds to HH:MM:SS."""
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    return f"{h:02d}:{m:02d}:{s:02d}"
+
+
+def _seconds_to_srt_ts(seconds: float) -> str:
+    """Convert seconds to SRT timestamp HH:MM:SS,mmm."""
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = math.floor(seconds % 60)
+    ms = round((seconds - math.floor(seconds)) * 1000)
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def _seconds_to_vtt_ts(seconds: float) -> str:
+    """Convert seconds to VTT timestamp HH:MM:SS.mmm."""
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = math.floor(seconds % 60)
+    ms = round((seconds - math.floor(seconds)) * 1000)
+    return f"{h:02d}:{m:02d}:{s:02d}.{ms:03d}"
+
+
+def _title(transcription: Any) -> str:
+    return transcription.title or transcription.original_filename
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TXT
+# ─────────────────────────────────────────────────────────────────────────────
+
+def export_txt(transcription: Any) -> bytes:
+    """Plain text export — speaker labels + timestamps per segment, or raw text for whisper."""
+    speakers: dict = transcription.speakers or {}
+    segments: list = transcription.segments or []
+    lines: list[str] = []
+
+    lines.append(_title(transcription))
+    lines.append("=" * len(_title(transcription)))
+    lines.append("")
+
+    if segments:
+        prev_speaker = None
+        for seg in segments:
+            speaker_raw = seg.get("speaker")
+            speaker = _resolve_speaker(speaker_raw, speakers) if speaker_raw else None
+            start = _seconds_to_hms(seg.get("start", 0))
+            text = seg.get("text", "").strip()
+            if not text:
+                continue
+            if speaker and speaker != prev_speaker:
+                lines.append(f"[{start}] {speaker}")
+                prev_speaker = speaker
+            elif not speaker:
+                lines.append(f"[{start}]")
+            lines.append(text)
+            lines.append("")
+    elif transcription.text:
+        lines.append(transcription.text)
+
+    return "\n".join(lines).encode("utf-8")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SRT
+# ─────────────────────────────────────────────────────────────────────────────
+
+def export_srt(transcription: Any) -> bytes:
+    """SubRip (.srt) subtitle export."""
+    speakers: dict = transcription.speakers or {}
+    segments: list = transcription.segments or []
+    lines: list[str] = []
+
+    for i, seg in enumerate(segments, start=1):
+        start = _seconds_to_srt_ts(seg.get("start", 0))
+        end = _seconds_to_srt_ts(seg.get("end", seg.get("start", 0) + 1))
+        text = seg.get("text", "").strip()
+        if not text:
+            continue
+        speaker_raw = seg.get("speaker")
+        if speaker_raw:
+            speaker = _resolve_speaker(speaker_raw, speakers)
+            text = f"[{speaker}] {text}"
+        lines.append(str(i))
+        lines.append(f"{start} --> {end}")
+        lines.append(text)
+        lines.append("")
+
+    return "\n".join(lines).encode("utf-8")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# VTT
+# ─────────────────────────────────────────────────────────────────────────────
+
+def export_vtt(transcription: Any) -> bytes:
+    """WebVTT (.vtt) subtitle export."""
+    speakers: dict = transcription.speakers or {}
+    segments: list = transcription.segments or []
+    lines: list[str] = ["WEBVTT", ""]
+
+    for seg in segments:
+        start = _seconds_to_vtt_ts(seg.get("start", 0))
+        end = _seconds_to_vtt_ts(seg.get("end", seg.get("start", 0) + 1))
+        text = seg.get("text", "").strip()
+        if not text:
+            continue
+        speaker_raw = seg.get("speaker")
+        if speaker_raw:
+            speaker = _resolve_speaker(speaker_raw, speakers)
+            text = f"<v {speaker}>{text}"
+        lines.append(f"{start} --> {end}")
+        lines.append(text)
+        lines.append("")
+
+    return "\n".join(lines).encode("utf-8")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Markdown
+# ─────────────────────────────────────────────────────────────────────────────
+
+def export_md(transcription: Any, summaries: Optional[list] = None) -> bytes:
+    """Markdown export — structured document with metadata, transcript, and summaries."""
+    speakers: dict = transcription.speakers or {}
+    segments: list = transcription.segments or []
+    is_whisper = str(transcription.recording_type) in ("whisper", "RecordingType.whisper")
+    lines: list[str] = []
+
+    # Header
+    lines.append(f"# {_title(transcription)}")
+    lines.append("")
+
+    # Metadata
+    rec_type = "Whisper memo" if is_whisper else "Recording"
+    lines.append(f"**Type:** {rec_type}  ")
+    if transcription.audio_duration:
+        lines.append(f"**Duration:** {_seconds_to_hms(transcription.audio_duration)}  ")
+    if transcription.language:
+        lines.append(f"**Language:** {transcription.language}  ")
+    lines.append("")
+
+    # Summaries (if any)
+    if summaries:
+        for summary in summaries:
+            lines.append("---")
+            lines.append("")
+            lines.append("## Summary")
+            lines.append("")
+            lines.append(summary.content)
+            lines.append("")
+
+    lines.append("---")
+    lines.append("")
+
+    # Transcript body
+    if is_whisper:
+        lines.append("## Transcript")
+        lines.append("")
+        lines.append(transcription.text or "")
+    else:
+        lines.append("## Transcript")
+        lines.append("")
+        if segments:
+            prev_speaker = None
+            for seg in segments:
+                speaker_raw = seg.get("speaker")
+                speaker = _resolve_speaker(speaker_raw, speakers) if speaker_raw else None
+                start = _seconds_to_hms(seg.get("start", 0))
+                text = seg.get("text", "").strip()
+                if not text:
+                    continue
+                if speaker and speaker != prev_speaker:
+                    lines.append(f"**[{start}] {speaker}**")
+                    prev_speaker = speaker
+                lines.append(text)
+                lines.append("")
+        elif transcription.text:
+            lines.append(transcription.text)
+
+    return "\n".join(lines).encode("utf-8")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DOCX
+# ─────────────────────────────────────────────────────────────────────────────
+
+def export_docx(transcription: Any, summaries: Optional[list] = None) -> bytes:
+    """Microsoft Word (.docx) export."""
+    from docx import Document
+    from docx.shared import Pt, RGBColor
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+
+    doc = Document()
+
+    # ── Styles ──
+    style = doc.styles["Normal"]
+    style.font.name = "Calibri"
+    style.font.size = Pt(11)
+
+    # ── Title ──
+    title_para = doc.add_heading(_title(transcription), level=1)
+    title_para.alignment = WD_ALIGN_PARAGRAPH.LEFT
+
+    # ── Metadata table ──
+    is_whisper = str(transcription.recording_type) in ("whisper", "RecordingType.whisper")
+    rec_type = "Whisper memo" if is_whisper else "Recording"
+    meta_lines = [f"Type: {rec_type}"]
+    if transcription.audio_duration:
+        meta_lines.append(f"Duration: {_seconds_to_hms(transcription.audio_duration)}")
+    if transcription.language:
+        meta_lines.append(f"Language: {transcription.language}")
+
+    meta_para = doc.add_paragraph()
+    for line in meta_lines:
+        run = meta_para.add_run(line + "\n")
+        run.font.color.rgb = RGBColor(0x60, 0x60, 0x60)
+        run.font.size = Pt(10)
+
+    doc.add_paragraph()
+
+    # ── Summaries ──
+    if summaries:
+        for summary in summaries:
+            doc.add_heading("Summary", level=2)
+            _add_markdown_paragraphs(doc, summary.content)
+            doc.add_paragraph()
+
+    # ── Transcript ──
+    doc.add_heading("Transcript", level=2)
+
+    speakers: dict = transcription.speakers or {}
+    segments: list = transcription.segments or []
+
+    if is_whisper:
+        doc.add_paragraph(transcription.text or "")
+    elif segments:
+        prev_speaker = None
+        for seg in segments:
+            speaker_raw = seg.get("speaker")
+            speaker = _resolve_speaker(speaker_raw, speakers) if speaker_raw else None
+            start = _seconds_to_hms(seg.get("start", 0))
+            text = seg.get("text", "").strip()
+            if not text:
+                continue
+            if speaker and speaker != prev_speaker:
+                speaker_para = doc.add_paragraph()
+                run = speaker_para.add_run(f"[{start}]  {speaker}")
+                run.bold = True
+                run.font.color.rgb = RGBColor(0x1D, 0x4E, 0xD8)
+                run.font.size = Pt(10)
+                prev_speaker = speaker
+            doc.add_paragraph(text)
+    elif transcription.text:
+        doc.add_paragraph(transcription.text)
+
+    # ── Save to bytes ──
+    buf = io.BytesIO()
+    doc.save(buf)
+    buf.seek(0)
+    return buf.read()
+
+
+def _add_markdown_paragraphs(doc: Any, content: str) -> None:
+    """Naive markdown-to-docx renderer for summary content."""
+    from docx.shared import Pt, RGBColor
+
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            doc.add_paragraph()
+            continue
+        if stripped.startswith("### "):
+            doc.add_heading(stripped[4:], level=4)
+        elif stripped.startswith("## "):
+            doc.add_heading(stripped[3:], level=3)
+        elif stripped.startswith("# "):
+            doc.add_heading(stripped[2:], level=2)
+        elif stripped.startswith("- [ ] ") or stripped.startswith("- [x] "):
+            checked = stripped[3] == "x"
+            text = stripped[6:]
+            p = doc.add_paragraph(style="List Bullet")
+            run = p.add_run(("☑ " if checked else "☐ ") + text)
+            run.font.size = Pt(11)
+        elif stripped.startswith("- ") or stripped.startswith("* "):
+            p = doc.add_paragraph(style="List Bullet")
+            p.add_run(stripped[2:])
+        elif stripped.startswith("| "):
+            # Simple table row — just render as plain text
+            doc.add_paragraph(stripped)
+        else:
+            # Handle inline bold (**text**)
+            p = doc.add_paragraph()
+            _render_inline(p, stripped)
+
+
+def _render_inline(para: Any, text: str) -> None:
+    """Render inline markdown bold/italic into a paragraph."""
+    import re
+    parts = re.split(r"(\*\*[^*]+\*\*|\*[^*]+\*)", text)
+    for part in parts:
+        if part.startswith("**") and part.endswith("**"):
+            run = para.add_run(part[2:-2])
+            run.bold = True
+        elif part.startswith("*") and part.endswith("*"):
+            run = para.add_run(part[1:-1])
+            run.italic = True
+        else:
+            para.add_run(part)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ authlib==1.3.1
 aiofiles==24.1.0
 cryptography>=42.0.0
 numpy>=1.24.0
+python-docx>=1.1.0

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,0 +1,83 @@
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: openhinotes
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - hinotes-internal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - hinotes-internal
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:${POSTGRES_PASSWORD:-postgres}@db:5432/openhinotes
+      SECRET_KEY: ${SECRET_KEY:-change-me-in-production-use-a-long-random-string}
+      VOXHUB_API_URL: ${VOXHUB_API_URL:-http://voxhub:8000}
+      VOXHUB_MODEL: ${VOXHUB_MODEL:-large-v3}
+      VOXHUB_VERIFY_SSL: ${VOXHUB_VERIFY_SSL:-true}
+      LLM_API_URL: ${LLM_API_URL:-http://host.docker.internal:11434/v1}
+      LLM_API_KEY: ${LLM_API_KEY:-}
+      LLM_MODEL: ${LLM_MODEL:-gpt-3.5-turbo}
+      LLM_VERIFY_SSL: ${LLM_VERIFY_SSL:-true}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@openhinotes.local}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin}
+      CORS_ORIGINS: '["*"]'
+    volumes:
+      - uploads_data:/app/uploads
+
+  frontend:
+    container_name: hinotes-frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    depends_on:
+      - backend
+    networks:
+      - hinotes-internal
+    environment:
+      - SITE_HOST=${SITE_HOST:-localhost}
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      - frontend
+      - backend
+    networks:
+      - hinotes-internal
+    ports:
+      - "${HTTP_PORT:-80}:80"
+      - "${HTTPS_PORT:-443}:443"
+    volumes:
+      - ./Caddyfile.standalone:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  postgres_data:
+  uploads_data:
+  caddy_data:
+  caddy_config:
+
+networks:
+  hinotes-internal:
+    name: hinotes-internal-standalone
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   db:
     image: postgres:16-alpine
@@ -7,11 +5,11 @@ services:
     environment:
       POSTGRES_DB: openhinotes
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
+    networks:
+      - hinotes-internal
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -26,8 +24,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    networks:
+      - hinotes-internal
     environment:
-      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/openhinotes
+      DATABASE_URL: postgresql+asyncpg://postgres:${POSTGRES_PASSWORD:-postgres}@db:5432/openhinotes
       SECRET_KEY: ${SECRET_KEY:-change-me-in-production-use-a-long-random-string}
       VOXHUB_API_URL: ${VOXHUB_API_URL:-http://voxhub:8000}
       VOXHUB_MODEL: ${VOXHUB_MODEL:-large-v3}
@@ -41,39 +41,28 @@ services:
       CORS_ORIGINS: '["*"]'
     volumes:
       - uploads_data:/app/uploads
-    ports:
-      - "8200:8000"
 
   frontend:
+    container_name: hinotes-frontend
     build:
       context: ./frontend
       dockerfile: Dockerfile
     restart: unless-stopped
     depends_on:
       - backend
+    networks:
+      - hinotes-internal
+      - proxy-net
     environment:
       - SITE_HOST=${SITE_HOST:-localhost}
-    ports:
-      - "5173:5173"
-
-  caddy:
-    image: caddy:2-alpine
-    restart: unless-stopped
-    depends_on:
-      - frontend
-      - backend
-    environment:
-      - SITE_HOST=${SITE_HOST:-localhost}
-    ports:
-      - "8880:80"
-      - "8443:443"
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
-      - caddy_data:/data
-      - caddy_config:/config
 
 volumes:
   postgres_data:
   uploads_data:
-  caddy_data:
-  caddy_config:
+
+networks:
+  hinotes-internal:
+    name: hinotes-internal
+    driver: bridge
+  proxy-net:
+    external: true

--- a/docs/STANDALONE_QUICKSTART.md
+++ b/docs/STANDALONE_QUICKSTART.md
@@ -1,0 +1,131 @@
+# Standalone Quick Start (no external reverse proxy)
+
+This guide gets OpenHiNotes running on a single machine in under five minutes using a bundled Caddy container with a self-signed certificate — no external reverse proxy, no domain name, no extra setup.
+
+> **Use this for:** local testing, evaluation, or a single-user home setup.
+> **For production** (shared server, real domain, Let's Encrypt), see the [main README](../README.md).
+
+---
+
+## What's different from the default setup
+
+| | Standalone | Default |
+|---|---|---|
+| Reverse proxy | Caddy bundled in compose | Your own (Caddy, Nginx, Traefik…) |
+| TLS | Self-signed (browser warning) | Managed by your proxy |
+| Ports exposed | 80 + 443 on the host | None |
+| External Docker network | Not needed | `proxy-net` required |
+| WebUSB (HiDock) | ✅ Works (HTTPS present) | ✅ Works |
+
+---
+
+## Prerequisites
+
+- Docker and Docker Compose
+- A running [VoxHub](https://github.com/ghecko/VoxHub) instance
+- An OpenAI-compatible LLM endpoint (optional — needed for chat/summaries)
+
+---
+
+## Steps
+
+### 1. Clone the repo
+
+```bash
+git clone https://github.com/ghecko/OpenHiNotes.git
+cd OpenHiNotes
+```
+
+### 2. Create your `.env`
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and set at minimum:
+
+```env
+VOXHUB_API_URL=http://your-voxhub-host:8000
+LLM_API_URL=http://host.docker.internal:11434/v1   # e.g. local Ollama
+```
+
+Everything else has sensible defaults for local use. You can leave `SITE_HOST` as `localhost`.
+
+### 3. Start
+
+```bash
+docker compose -f docker-compose.standalone.yml up -d --build
+```
+
+This starts: PostgreSQL, FastAPI backend, React/Nginx frontend, and a Caddy reverse proxy with a self-signed certificate.
+
+### 4. Open in your browser
+
+Go to **https://localhost** and accept the self-signed certificate warning (click "Advanced" → "Proceed").
+
+> Browsers flag self-signed certificates as untrusted — this is expected. The connection is still encrypted.
+
+Log in with the default credentials:
+
+| Field    | Default                    |
+|----------|----------------------------|
+| Email    | `admin@openhinotes.local`  |
+| Password | `admin`                    |
+
+**Change the password after your first login.**
+
+---
+
+## Optional: custom hostname or port
+
+If port 443 is already in use, set `HTTPS_PORT` in your `.env`:
+
+```env
+HTTPS_PORT=8443
+SITE_HOST=localhost
+```
+
+Then access the app at **https://localhost:8443**.
+
+To use a custom local hostname (e.g. `hinotes.local`):
+
+```env
+SITE_HOST=hinotes.local
+```
+
+Add `127.0.0.1  hinotes.local` to your `/etc/hosts` (or `C:\Windows\System32\drivers\etc\hosts` on Windows), then open **https://hinotes.local**.
+
+---
+
+## Stopping and cleaning up
+
+```bash
+# Stop containers (keeps data)
+docker compose -f docker-compose.standalone.yml down
+
+# Stop and delete all data (volumes)
+docker compose -f docker-compose.standalone.yml down -v
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| Port 80 / 443 already in use | Set `HTTP_PORT` and `HTTPS_PORT` in `.env` |
+| "Connection refused" on https://localhost | Wait ~30 s for the build to finish, then retry |
+| VoxHub errors | Check `VOXHUB_API_URL` points to a running VoxHub instance |
+| LLM errors | Check `LLM_API_URL`; for Ollama on the host use `http://host.docker.internal:11434/v1` |
+| WebUSB not detecting device | Ensure you are on HTTPS (not HTTP) and using Chrome/Edge |
+
+---
+
+## Upgrading
+
+```bash
+git pull
+docker compose -f docker-compose.standalone.yml up -d --build
+```
+
+Database migrations run automatically on startup.

--- a/frontend/src/pages/TranscriptionDetail.tsx
+++ b/frontend/src/pages/TranscriptionDetail.tsx
@@ -99,6 +99,20 @@ export function TranscriptionDetail() {
   // Share modal
   const [showShareModal, setShowShareModal] = useState(false);
 
+  // Export dropdown
+  const [showExportMenu, setShowExportMenu] = useState(false);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (exportMenuRef.current && !exportMenuRef.current.contains(e.target as Node)) {
+        setShowExportMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
   // Derived permission
   const permissionLevel = transcription?.permission_level || 'owner';
   const canEdit = permissionLevel === 'owner' || permissionLevel === 'write';
@@ -530,20 +544,6 @@ export function TranscriptionDetail() {
     });
     downloadFile(lines.join('\n'), `${baseName}.txt`, 'text/plain');
   };
-
-  // ── Export dropdown ──
-  const [showExportMenu, setShowExportMenu] = useState(false);
-  const exportMenuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (exportMenuRef.current && !exportMenuRef.current.contains(e.target as Node)) {
-        setShowExportMenu(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, []);
 
   const handleExport = (fmt: string) => {
     setShowExportMenu(false);

--- a/frontend/src/pages/TranscriptionDetail.tsx
+++ b/frontend/src/pages/TranscriptionDetail.tsx
@@ -13,7 +13,7 @@ import { useDeviceConnection } from '@/hooks/useDeviceConnection';
 import { deviceService } from '@/services/deviceService';
 import { Transcription, Summary, SummaryTemplate, Collection } from '@/types';
 import { format } from 'date-fns';
-import { Save, Loader, Plus, Pencil, Trash2, X, FileText, Maximize2, Download, Play, Pause, Volume2, Disc3, Share2, Lock, Eye } from 'lucide-react';
+import { Save, Loader, Plus, Pencil, Trash2, X, FileText, Maximize2, Download, Play, Pause, Volume2, Disc3, Share2, Lock, Eye, ChevronDown } from 'lucide-react';
 import { ShareModal } from '@/components/ShareModal';
 import { InteractiveMarkdown } from '@/components/InteractiveMarkdown';
 import { TemplateSelector } from '@/components/TemplateSelector';
@@ -531,6 +531,40 @@ export function TranscriptionDetail() {
     downloadFile(lines.join('\n'), `${baseName}.txt`, 'text/plain');
   };
 
+  // ── Export dropdown ──
+  const [showExportMenu, setShowExportMenu] = useState(false);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (exportMenuRef.current && !exportMenuRef.current.contains(e.target as Node)) {
+        setShowExportMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const handleExport = (fmt: string) => {
+    setShowExportMenu(false);
+    const token = localStorage.getItem('auth_token');
+    const url = `/api/transcriptions/${transcription.id}/export?format=${fmt}`;
+    // Use anchor click so the browser triggers a download with the correct filename
+    const a = document.createElement('a');
+    a.href = token ? `${url}&token=${token}` : url;
+    // Let the server provide the filename via Content-Disposition
+    a.setAttribute('download', '');
+    // Use fetch + blob for authenticated requests
+    fetch(url, { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => r.blob())
+      .then((blob) => {
+        const objectUrl = URL.createObjectURL(blob);
+        a.href = objectUrl;
+        a.click();
+        URL.revokeObjectURL(objectUrl);
+      });
+  };
+
   return (
     <Layout title={displayTitle}>
       <div className="space-y-6">
@@ -598,26 +632,51 @@ export function TranscriptionDetail() {
               </button>
             )}
 
-            {/* Download buttons */}
+            {/* Export dropdown */}
             {transcription.status === 'completed' && (
-              <>
+              <div className="relative" ref={exportMenuRef}>
                 <button
-                  onClick={handleDownloadJSON}
+                  onClick={() => setShowExportMenu((v) => !v)}
                   className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
-                  title="Download as JSON with timestamps"
                 >
                   <Download className="w-3.5 h-3.5" />
-                  JSON
+                  Export
+                  <ChevronDown className="w-3 h-3" />
                 </button>
-                <button
-                  onClick={handleDownloadTXT}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
-                  title="Download as plain text with timestamps"
-                >
-                  <Download className="w-3.5 h-3.5" />
-                  TXT
-                </button>
-              </>
+                {showExportMenu && (
+                  <div className="absolute right-0 mt-1 w-44 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-20 overflow-hidden">
+                    {(isWhisper
+                      ? [
+                          { fmt: 'txt', label: 'Plain Text (.txt)' },
+                          { fmt: 'md',  label: 'Markdown (.md)' },
+                          { fmt: 'docx', label: 'Word (.docx)' },
+                        ]
+                      : [
+                          { fmt: 'txt',  label: 'Plain Text (.txt)' },
+                          { fmt: 'srt',  label: 'Subtitles (.srt)' },
+                          { fmt: 'vtt',  label: 'WebVTT (.vtt)' },
+                          { fmt: 'md',   label: 'Markdown (.md)' },
+                          { fmt: 'docx', label: 'Word (.docx)' },
+                        ]
+                    ).map(({ fmt, label }) => (
+                      <button
+                        key={fmt}
+                        onClick={() => handleExport(fmt)}
+                        className="w-full text-left px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                      >
+                        {label}
+                      </button>
+                    ))}
+                    <div className="border-t border-gray-100 dark:border-gray-700" />
+                    <button
+                      onClick={() => { setShowExportMenu(false); handleDownloadJSON(); }}
+                      className="w-full text-left px-4 py-2.5 text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                    >
+                      Raw JSON (.json)
+                    </button>
+                  </div>
+                )}
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary

### Sprint 4 — Export (5.1)
- New `GET /api/transcriptions/{id}/export?format=...` endpoint supporting five formats:
  - **txt** — plain text with speaker labels and timestamps per segment
  - **srt** — SubRip subtitles with speaker labels (record only)
  - **vtt** — WebVTT subtitles with `<v Speaker>` tags (record only)
  - **md** — Markdown document with metadata header, summaries, and formatted transcript
  - **docx** — Word document with styled speaker blocks and inline markdown rendering for summaries
- Whisper recordings offer txt / md / docx only (no segments → no subtitles)
- Replace old JSON/TXT download buttons with a unified **Export** dropdown on the transcription detail page
- Add `python-docx` dependency for Word document generation

### Docker Compose — network isolation
- Remove all host-exposed ports — db and backend are internal only, frontend joins `proxy-net` for the external reverse proxy to reach
- Remove bundled Caddy service — OpenHiNotes now sits cleanly behind whatever reverse proxy the host already runs
- `POSTGRES_PASSWORD` is now env-var driven instead of hardcoded

### Standalone quickstart (no reverse proxy needed)
- Add `docker-compose.standalone.yml` and `Caddyfile.standalone` — a self-contained setup that bundles Caddy with a self-signed certificate for quick local testing
- Add `docs/STANDALONE_QUICKSTART.md` — step-by-step guide covering setup, custom ports, hostname configuration, browser cert warning, and troubleshooting
- Update README: architecture diagram rewritten around the external proxy model, Quick Start section split between the standalone guide (linked prominently) and the production/integration path

## Test plan

- [ ] Download a completed record transcription as each format — verify content and filename
- [ ] Download a whisper transcription — SRT and VTT absent from dropdown, txt/md/docx work correctly
- [ ] `.docx` and `.md` include the summary section when a summary exists
- [ ] Shared (read-only) transcriptions can be exported by the shared-with user
- [ ] Incomplete transcriptions return 400 on export attempt
- [ ] `docker compose up -d --build` (default) starts cleanly with no host-exposed ports — verify with `docker compose ps`
- [ ] Reverse proxy can reach `hinotes-frontend` by container name on port 80
- [ ] `docker compose -f docker-compose.standalone.yml up -d --build` starts cleanly and is accessible at **https://localhost** after accepting the self-signed cert warning