### PR TITLE
Phase3 sprint5

### DIFF
--- a/backend/alembic/versions/020_user_group_owner_policy.py
+++ b/backend/alembic/versions/020_user_group_owner_policy.py
@@ -1,0 +1,56 @@
+"""Add owner_id and sharing_policy to user_groups.
+
+Revision ID: 020_user_group_owner_policy
+Revises: 019_template_target_type
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "020_user_group_owner_policy"
+down_revision = "019_template_target_type"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create the SharingPolicy enum type
+    sharing_policy_enum = sa.Enum("creator_only", "members_allowed", name="sharingpolicy")
+    sharing_policy_enum.create(op.get_bind(), checkfirst=True)
+
+    # Add owner_id — nullable first so we can backfill from created_by
+    op.add_column(
+        "user_groups",
+        sa.Column("owner_id", sa.UUID(), nullable=True),
+    )
+
+    # Backfill owner_id from created_by for all existing groups
+    op.execute("UPDATE user_groups SET owner_id = created_by WHERE owner_id IS NULL")
+
+    # Now make it non-nullable and add FK + index
+    op.alter_column("user_groups", "owner_id", nullable=False)
+    op.create_foreign_key(
+        "fk_user_groups_owner_id",
+        "user_groups", "users",
+        ["owner_id"], ["id"],
+    )
+    op.create_index("ix_user_groups_owner_id", "user_groups", ["owner_id"])
+
+    # Add sharing_policy column
+    op.add_column(
+        "user_groups",
+        sa.Column(
+            "sharing_policy",
+            sa.Enum("creator_only", "members_allowed", name="sharingpolicy"),
+            nullable=False,
+            server_default="creator_only",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_groups_owner_id", table_name="user_groups")
+    op.drop_constraint("fk_user_groups_owner_id", "user_groups", type_="foreignkey")
+    op.drop_column("user_groups", "sharing_policy")
+    op.drop_column("user_groups", "owner_id")
+    sa.Enum(name="sharingpolicy").drop(op.get_bind(), checkfirst=True)

--- a/backend/alembic/versions/021_user_group_name_unique.py
+++ b/backend/alembic/versions/021_user_group_name_unique.py
@@ -1,8 +1,9 @@
-"""Make user_groups.name globally unique.
+"""Make user_groups.name globally unique (case-insensitive, whitespace-trimmed).
 
-Before applying the UNIQUE constraint, rename any existing duplicates
-by appending " (2)", " (3)", ... so the migration succeeds on databases
-that already have duplicates.
+Normalizes existing names (trim, collapse whitespace), renames any
+remaining case-insensitive duplicates with a " (N)" suffix, then
+applies a unique index on lower(name) so future inserts can't collide
+on case or trailing spaces.
 
 Revision ID: 021_user_group_name_unique
 Revises: 020_user_group_owner_policy
@@ -18,12 +19,18 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Rename duplicates by created_at order: first one keeps the name,
-    # subsequent ones get " (2)", " (3)", ... suffix
+    # 1. Normalize: trim and collapse internal whitespace runs
+    op.execute(r"""
+        UPDATE user_groups
+        SET name = regexp_replace(btrim(name), '\s+', ' ', 'g')
+        WHERE name <> regexp_replace(btrim(name), '\s+', ' ', 'g')
+    """)
+
+    # 2. Rename case-insensitive duplicates with " (N)" suffix
     op.execute("""
         WITH ranked AS (
             SELECT id, name,
-                   ROW_NUMBER() OVER (PARTITION BY name ORDER BY created_at, id) AS rn
+                   ROW_NUMBER() OVER (PARTITION BY lower(name) ORDER BY created_at, id) AS rn
             FROM user_groups
         )
         UPDATE user_groups g
@@ -32,8 +39,9 @@ def upgrade() -> None:
         WHERE g.id = ranked.id AND ranked.rn > 1
     """)
 
-    op.create_unique_constraint("uq_user_groups_name", "user_groups", ["name"])
+    # 3. Functional unique index — case-insensitive
+    op.execute("CREATE UNIQUE INDEX uq_user_groups_name_lower ON user_groups (lower(name))")
 
 
 def downgrade() -> None:
-    op.drop_constraint("uq_user_groups_name", "user_groups", type_="unique")
+    op.execute("DROP INDEX IF EXISTS uq_user_groups_name_lower")

--- a/backend/alembic/versions/021_user_group_name_unique.py
+++ b/backend/alembic/versions/021_user_group_name_unique.py
@@ -1,0 +1,39 @@
+"""Make user_groups.name globally unique.
+
+Before applying the UNIQUE constraint, rename any existing duplicates
+by appending " (2)", " (3)", ... so the migration succeeds on databases
+that already have duplicates.
+
+Revision ID: 021_user_group_name_unique
+Revises: 020_user_group_owner_policy
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "021_user_group_name_unique"
+down_revision = "020_user_group_owner_policy"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Rename duplicates by created_at order: first one keeps the name,
+    # subsequent ones get " (2)", " (3)", ... suffix
+    op.execute("""
+        WITH ranked AS (
+            SELECT id, name,
+                   ROW_NUMBER() OVER (PARTITION BY name ORDER BY created_at, id) AS rn
+            FROM user_groups
+        )
+        UPDATE user_groups g
+        SET name = g.name || ' (' || ranked.rn || ')'
+        FROM ranked
+        WHERE g.id = ranked.id AND ranked.rn > 1
+    """)
+
+    op.create_unique_constraint("uq_user_groups_name", "user_groups", ["name"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_user_groups_name", "user_groups", type_="unique")

--- a/backend/app/models/user_group.py
+++ b/backend/app/models/user_group.py
@@ -1,8 +1,14 @@
-from sqlalchemy import String, DateTime, ForeignKey, Text, Table, Column
+from sqlalchemy import String, DateTime, ForeignKey, Text, Table, Column, Enum as SQLEnum
 from sqlalchemy.orm import mapped_column, Mapped, relationship
 import uuid
 from datetime import datetime
+from enum import Enum
 from app.database import Base
+
+
+class SharingPolicy(str, Enum):
+    creator_only = "creator_only"      # only the group owner can share resources to this group
+    members_allowed = "members_allowed"  # any member can share resources to this group
 
 
 # Association table for group membership (M:N)
@@ -24,6 +30,16 @@ class UserGroup(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=True)
     created_by: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
+    # owner_id tracks the current owner (defaults to creator, transferable in future)
+    owner_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id"), nullable=False, index=True
+    )
+    sharing_policy: Mapped[SharingPolicy] = mapped_column(
+        SQLEnum(SharingPolicy),
+        nullable=False,
+        default=SharingPolicy.creator_only,
+        server_default="creator_only",
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
@@ -31,6 +47,7 @@ class UserGroup(Base):
 
     # Relationships
     creator: Mapped["User"] = relationship(foreign_keys=[created_by])
+    owner: Mapped["User"] = relationship(foreign_keys=[owner_id])
     members: Mapped[list["User"]] = relationship(
         secondary=user_group_members, lazy="selectin"
     )

--- a/backend/app/models/user_group.py
+++ b/backend/app/models/user_group.py
@@ -27,7 +27,7 @@ class UserGroup(Base):
     __tablename__ = "user_groups"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     description: Mapped[str] = mapped_column(Text, nullable=True)
     created_by: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     # owner_id tracks the current owner (defaults to creator, transferable in future)

--- a/backend/app/routers/app_settings.py
+++ b/backend/app/routers/app_settings.py
@@ -296,6 +296,53 @@ async def update_audio_settings(
     return {"keep_audio_enabled": body.keep_audio_enabled}
 
 
+# ── Groups Settings ────────────────────────────────────────────────────
+
+ALLOW_USER_GROUP_CREATION_KEY = "allow_user_group_creation"
+
+
+class GroupsSettingsUpdate(BaseModel):
+    allow_user_group_creation: bool
+
+
+@router.get("/groups")
+async def get_groups_settings(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get group-related settings. Available to all authenticated users."""
+    result = await db.execute(
+        select(AppSetting).where(AppSetting.key == ALLOW_USER_GROUP_CREATION_KEY)
+    )
+    setting = result.scalars().first()
+    allowed = setting.value.lower() == "true" if setting else False  # default: disabled
+    return {"allow_user_group_creation": allowed}
+
+
+@router.put("/groups")
+async def update_groups_settings(
+    body: GroupsSettingsUpdate,
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update group creation settings (admin only)."""
+    result = await db.execute(
+        select(AppSetting).where(AppSetting.key == ALLOW_USER_GROUP_CREATION_KEY)
+    )
+    setting = result.scalars().first()
+    if setting:
+        setting.value = str(body.allow_user_group_creation).lower()
+    else:
+        setting = AppSetting(
+            key=ALLOW_USER_GROUP_CREATION_KEY,
+            value=str(body.allow_user_group_creation).lower(),
+            description="Allow non-admin users to create their own groups",
+        )
+        db.add(setting)
+    await db.commit()
+    return {"allow_user_group_creation": body.allow_user_group_creation}
+
+
 # ── Generic key/value settings ─────────────────────────────────────────
 
 

--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -128,14 +128,23 @@ async def create_group(
                 detail="Group creation is restricted to administrators",
             )
 
-    # Name must be globally unique — return friendly 409 instead of DB IntegrityError
+    # Normalize name: strip whitespace, collapse internal runs, reject if empty
+    name = " ".join((group_create.name or "").split())
+    if not name:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Group name cannot be empty",
+        )
+
+    # Globally unique (case-insensitive) — return friendly 409 instead of DB IntegrityError
+    from sqlalchemy import func
     name_clash = await db.execute(
-        select(UserGroup).where(UserGroup.name == group_create.name)
+        select(UserGroup).where(func.lower(UserGroup.name) == name.lower())
     )
     if name_clash.scalars().first():
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"A group named '{group_create.name}' already exists",
+            detail=f"A group named '{name}' already exists",
         )
 
     policy = SharingPolicy.creator_only
@@ -143,7 +152,7 @@ async def create_group(
         policy = SharingPolicy(group_create.sharing_policy)
 
     group = UserGroup(
-        name=group_create.name,
+        name=name,
         description=group_create.description,
         created_by=current_user.id,
         owner_id=current_user.id,
@@ -241,20 +250,27 @@ async def update_group(
     if not _is_group_owner(group, current_user):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the group owner can edit this group")
 
-    if group_update.name is not None and group_update.name != group.name:
-        # Name must be globally unique
-        name_clash = await db.execute(
-            select(UserGroup).where(
-                UserGroup.name == group_update.name,
-                UserGroup.id != group_id,
-            )
-        )
-        if name_clash.scalars().first():
+    if group_update.name is not None:
+        new_name = " ".join(group_update.name.split())
+        if not new_name:
             raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"A group named '{group_update.name}' already exists",
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Group name cannot be empty",
             )
-        group.name = group_update.name
+        if new_name.lower() != group.name.lower():
+            from sqlalchemy import func
+            name_clash = await db.execute(
+                select(UserGroup).where(
+                    func.lower(UserGroup.name) == new_name.lower(),
+                    UserGroup.id != group_id,
+                )
+            )
+            if name_clash.scalars().first():
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=f"A group named '{new_name}' already exists",
+                )
+        group.name = new_name
     if group_update.description is not None:
         group.description = group_update.description
     if group_update.sharing_policy is not None:

--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -12,16 +12,34 @@ from app.schemas.user_group import (
     GroupMemberResponse,
 )
 from app.models.user import User, UserRole
-from app.models.user_group import UserGroup, user_group_members
+from app.models.user_group import UserGroup, user_group_members, SharingPolicy
+from app.models.app_settings import AppSetting
 from app.dependencies import get_current_user, require_admin
 
 router = APIRouter(prefix="/groups", tags=["groups"])
 
+ALLOW_USER_GROUP_CREATION_KEY = "allow_user_group_creation"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+async def _user_group_creation_allowed(db: AsyncSession) -> bool:
+    """Return True if non-admin users are allowed to create groups."""
+    result = await db.execute(
+        select(AppSetting).where(AppSetting.key == ALLOW_USER_GROUP_CREATION_KEY)
+    )
+    setting = result.scalars().first()
+    return setting.value.lower() == "true" if setting else False
+
+
+def _is_group_owner(group: UserGroup, user: User) -> bool:
+    return group.owner_id == user.id or user.role == UserRole.admin
+
 
 async def _enrich_with_member_count(
-    groups: list[UserGroup], db: AsyncSession
+    groups: list[UserGroup], db: AsyncSession, current_user: User | None = None
 ) -> list[dict]:
-    """Add member_count to each group."""
+    """Add member_count (and is_owner) to each group."""
     if not groups:
         return []
     group_ids = [g.id for g in groups]
@@ -42,26 +60,43 @@ async def _enrich_with_member_count(
             "name": g.name,
             "description": g.description,
             "created_by": g.created_by,
+            "owner_id": g.owner_id,
+            "sharing_policy": g.sharing_policy.value if hasattr(g.sharing_policy, "value") else g.sharing_policy,
             "created_at": g.created_at,
             "updated_at": g.updated_at,
             "member_count": counts.get(g.id, 0),
+            "is_owner": _is_group_owner(g, current_user) if current_user else False,
         }
         result.append(data)
     return result
 
 
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
 @router.get("", response_model=list[GroupResponse])
 async def list_groups(
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),
+    mine: bool = Query(False, description="Only return groups owned by the current user"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """List groups. Admins see all, users see groups they belong to."""
-    if current_user.role == UserRole.admin:
+    """List groups.
+    - Admins: see all groups (or just their own with mine=true)
+    - Users: see groups they belong to or own
+    """
+    if current_user.role == UserRole.admin and not mine:
         query = select(UserGroup).order_by(UserGroup.name).offset(skip).limit(limit)
+    elif mine:
+        query = (
+            select(UserGroup)
+            .where(UserGroup.owner_id == current_user.id)
+            .order_by(UserGroup.name)
+            .offset(skip)
+            .limit(limit)
+        )
     else:
-        # User sees groups they are a member of
+        # Member groups (includes owned groups since owner is also a member)
         query = (
             select(UserGroup)
             .join(user_group_members, UserGroup.id == user_group_members.c.group_id)
@@ -73,25 +108,51 @@ async def list_groups(
 
     result = await db.execute(query)
     groups = list(result.scalars().all())
-    return await _enrich_with_member_count(groups, db)
+    return await _enrich_with_member_count(groups, db, current_user)
 
 
 @router.post("", response_model=GroupResponse, status_code=status.HTTP_201_CREATED)
 async def create_group(
     group_create: GroupCreate,
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Create a new group (admin only)."""
+    """Create a new group.
+    - Admins: always allowed.
+    - Regular users: only when allow_user_group_creation setting is enabled.
+    """
+    if current_user.role != UserRole.admin:
+        if not await _user_group_creation_allowed(db):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Group creation is restricted to administrators",
+            )
+
+    policy = SharingPolicy.creator_only
+    if group_create.sharing_policy in ("creator_only", "members_allowed"):
+        policy = SharingPolicy(group_create.sharing_policy)
+
     group = UserGroup(
         name=group_create.name,
         description=group_create.description,
         created_by=current_user.id,
+        owner_id=current_user.id,
+        sharing_policy=policy,
     )
     db.add(group)
     await db.commit()
     await db.refresh(group)
-    enriched = await _enrich_with_member_count([group], db)
+
+    # Auto-add creator as a member of their own group
+    await db.execute(
+        user_group_members.insert().values(
+            group_id=group.id,
+            user_id=current_user.id,
+        )
+    )
+    await db.commit()
+
+    enriched = await _enrich_with_member_count([group], db, current_user)
     return enriched[0]
 
 
@@ -108,7 +169,7 @@ async def get_group(
     if not group:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
 
-    # Non-admin must be a member
+    # Non-admin must be a member or owner
     if current_user.role != UserRole.admin:
         member_check = await db.execute(
             select(user_group_members.c.user_id).where(
@@ -116,10 +177,9 @@ async def get_group(
                 user_group_members.c.user_id == current_user.id,
             )
         )
-        if not member_check.first():
+        if not member_check.first() and group.owner_id != current_user.id:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized")
 
-    # Get members
     members_result = await db.execute(
         select(User)
         .join(user_group_members, User.id == user_group_members.c.user_id)
@@ -133,6 +193,9 @@ async def get_group(
         "name": group.name,
         "description": group.description,
         "created_by": group.created_by,
+        "owner_id": group.owner_id,
+        "sharing_policy": group.sharing_policy.value if hasattr(group.sharing_policy, "value") else group.sharing_policy,
+        "is_owner": _is_group_owner(group, current_user),
         "created_at": group.created_at,
         "updated_at": group.updated_at,
         "member_count": len(members),
@@ -141,7 +204,7 @@ async def get_group(
                 "id": m.id,
                 "email": m.email,
                 "display_name": m.display_name,
-                "role": m.role.value if hasattr(m.role, 'value') else m.role,
+                "role": m.role.value if hasattr(m.role, "value") else m.role,
             }
             for m in members
         ],
@@ -152,41 +215,53 @@ async def get_group(
 async def update_group(
     group_id: uuid.UUID,
     group_update: GroupUpdate,
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update a group (admin only)."""
+    """Update a group.
+    - Admins: can update any group.
+    - Owner: can update their own group's name, description, and sharing_policy.
+    """
     result = await db.execute(select(UserGroup).where(UserGroup.id == group_id))
     group = result.scalars().first()
 
     if not group:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
 
+    if not _is_group_owner(group, current_user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the group owner can edit this group")
+
     if group_update.name is not None:
         group.name = group_update.name
     if group_update.description is not None:
         group.description = group_update.description
+    if group_update.sharing_policy is not None:
+        if group_update.sharing_policy not in ("creator_only", "members_allowed"):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid sharing_policy")
+        group.sharing_policy = SharingPolicy(group_update.sharing_policy)
 
     await db.commit()
     await db.refresh(group)
-    enriched = await _enrich_with_member_count([group], db)
+    enriched = await _enrich_with_member_count([group], db, current_user)
     return enriched[0]
 
 
 @router.delete("/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_group(
     group_id: uuid.UUID,
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Delete a group (admin only). Also removes associated shares."""
+    """Delete a group. Admins can delete any group; owners can delete their own."""
     result = await db.execute(select(UserGroup).where(UserGroup.id == group_id))
     group = result.scalars().first()
 
     if not group:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
 
-    # Delete group shares
+    if not _is_group_owner(group, current_user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the group owner can delete this group")
+
     from app.models.resource_share import ResourceShare, GranteeType
     shares_result = await db.execute(
         select(ResourceShare).where(
@@ -205,23 +280,23 @@ async def delete_group(
 async def add_member(
     group_id: uuid.UUID,
     member_add: GroupMemberAdd,
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Add a user to a group (admin only)."""
-    # Verify group exists
+    """Add a user to a group. Admins or group owner only."""
     result = await db.execute(select(UserGroup).where(UserGroup.id == group_id))
     group = result.scalars().first()
     if not group:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
 
-    # Verify user exists
+    if not _is_group_owner(group, current_user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the group owner can manage members")
+
     user_result = await db.execute(select(User).where(User.id == member_add.user_id))
     user = user_result.scalars().first()
     if not user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    # Check not already a member
     existing = await db.execute(
         select(user_group_members).where(
             user_group_members.c.group_id == group_id,
@@ -229,20 +304,12 @@ async def add_member(
         )
     )
     if existing.first():
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="User is already a member of this group",
-        )
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User is already a member of this group")
 
     await db.execute(
-        user_group_members.insert().values(
-            group_id=group_id,
-            user_id=member_add.user_id,
-        )
+        user_group_members.insert().values(group_id=group_id, user_id=member_add.user_id)
     )
     await db.commit()
-
-    # Return updated group detail
     return await get_group(group_id, current_user, db)
 
 
@@ -250,17 +317,29 @@ async def add_member(
 async def remove_member(
     group_id: uuid.UUID,
     user_id: uuid.UUID,
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Remove a user from a group (admin only)."""
-    result = await db.execute(
+    """Remove a user from a group. Admins or group owner only."""
+    result = await db.execute(select(UserGroup).where(UserGroup.id == group_id))
+    group = result.scalars().first()
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+
+    if not _is_group_owner(group, current_user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the group owner can manage members")
+
+    # Owner cannot remove themselves
+    if user_id == group.owner_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot remove the group owner")
+
+    member_result = await db.execute(
         select(user_group_members).where(
             user_group_members.c.group_id == group_id,
             user_group_members.c.user_id == user_id,
         )
     )
-    if not result.first():
+    if not member_result.first():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Member not found")
 
     await db.execute(

--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -128,6 +128,16 @@ async def create_group(
                 detail="Group creation is restricted to administrators",
             )
 
+    # Name must be globally unique — return friendly 409 instead of DB IntegrityError
+    name_clash = await db.execute(
+        select(UserGroup).where(UserGroup.name == group_create.name)
+    )
+    if name_clash.scalars().first():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A group named '{group_create.name}' already exists",
+        )
+
     policy = SharingPolicy.creator_only
     if group_create.sharing_policy in ("creator_only", "members_allowed"):
         policy = SharingPolicy(group_create.sharing_policy)
@@ -231,7 +241,19 @@ async def update_group(
     if not _is_group_owner(group, current_user):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the group owner can edit this group")
 
-    if group_update.name is not None:
+    if group_update.name is not None and group_update.name != group.name:
+        # Name must be globally unique
+        name_clash = await db.execute(
+            select(UserGroup).where(
+                UserGroup.name == group_update.name,
+                UserGroup.id != group_id,
+            )
+        )
+        if name_clash.scalars().first():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"A group named '{group_update.name}' already exists",
+            )
         group.name = group_update.name
     if group_update.description is not None:
         group.description = group_update.description

--- a/backend/app/routers/shares.py
+++ b/backend/app/routers/shares.py
@@ -11,7 +11,7 @@ from app.schemas.resource_share import (
     SharedWithMeItem,
 )
 from app.models.user import User, UserRole
-from app.models.user_group import UserGroup, user_group_members
+from app.models.user_group import UserGroup, user_group_members, SharingPolicy
 from app.models.transcription import Transcription
 from app.models.collection import Collection
 from app.models.resource_share import (
@@ -57,9 +57,37 @@ async def create_share(
         if not result.scalars().first():
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
     else:
-        result = await db.execute(select(UserGroup).where(UserGroup.id == share_create.grantee_id))
-        if not result.scalars().first():
+        grp_result = await db.execute(select(UserGroup).where(UserGroup.id == share_create.grantee_id))
+        target_group = grp_result.scalars().first()
+        if not target_group:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+
+        # Enforce sharing_policy (admins always bypass)
+        policy = target_group.sharing_policy
+        if hasattr(policy, "value"):
+            policy = policy.value
+
+        if current_user.role != UserRole.admin:
+            if policy == SharingPolicy.creator_only.value:
+                # Only the group owner can share
+                if target_group.owner_id != current_user.id:
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail="This group only allows its owner to share resources to it",
+                    )
+            else:
+                # members_allowed → the user must be a member of the group
+                member_check = await db.execute(
+                    select(user_group_members.c.user_id).where(
+                        user_group_members.c.group_id == target_group.id,
+                        user_group_members.c.user_id == current_user.id,
+                    )
+                )
+                if not member_check.first():
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail="You must be a member of this group to share resources to it",
+                    )
 
     # Check for existing share (upsert)
     existing_result = await db.execute(

--- a/backend/app/schemas/user_group.py
+++ b/backend/app/schemas/user_group.py
@@ -9,12 +9,14 @@ class GroupCreate(BaseModel):
     """Schema for creating a user group."""
     name: str
     description: Optional[str] = None
+    sharing_policy: Optional[str] = None  # "creator_only" | "members_allowed" (default: creator_only)
 
 
 class GroupUpdate(BaseModel):
     """Schema for updating a user group."""
     name: Optional[str] = None
     description: Optional[str] = None
+    sharing_policy: Optional[str] = None  # "creator_only" | "members_allowed"
 
 
 class GroupMemberAdd(BaseModel):
@@ -39,9 +41,12 @@ class GroupResponse(BaseModel):
     name: str
     description: Optional[str] = None
     created_by: uuid.UUID
+    owner_id: uuid.UUID
+    sharing_policy: str = "creator_only"
     created_at: datetime
     updated_at: datetime
     member_count: int = 0
+    is_owner: bool = False   # populated per-request, not from DB
 
     class Config:
         from_attributes = True

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { Collections } from '@/pages/Collections';
 import { CollectionDetail } from '@/pages/CollectionDetail';
 import { Chat } from '@/pages/Chat';
 import { Settings } from '@/pages/Settings';
+import { MyGroups } from '@/pages/MyGroups';
 import { AdminPanel } from '@/pages/admin/AdminPanel';
 
 // Components
@@ -149,6 +150,14 @@ function App() {
       {/* Redirect old admin routes to the new tabbed panel */}
       <Route path="/admin/users" element={<Navigate to="/admin?tab=users" replace />} />
       <Route path="/admin/groups" element={<Navigate to="/admin?tab=groups" replace />} />
+      <Route
+        path="/groups"
+        element={
+          <ProtectedRoute>
+            <MyGroups />
+          </ProtectedRoute>
+        }
+      />
       <Route path="/admin/templates" element={<Navigate to="/admin?tab=templates" replace />} />
       <Route path="/admin/registration" element={<Navigate to="/admin?tab=registration" replace />} />
       <Route path="/admin/email" element={<Navigate to="/admin?tab=email" replace />} />

--- a/frontend/src/api/groups.ts
+++ b/frontend/src/api/groups.ts
@@ -1,20 +1,20 @@
 import { apiClient } from './client';
-import { UserGroup, UserGroupDetail } from '@/types';
+import { UserGroup, UserGroupDetail, SharingPolicy } from '@/types';
 
 export const groupsApi = {
-  async list(): Promise<UserGroup[]> {
-    return apiClient.get<UserGroup[]>('/groups');
+  async list(mine = false): Promise<UserGroup[]> {
+    return apiClient.get<UserGroup[]>(`/groups${mine ? '?mine=true' : ''}`);
   },
 
   async get(id: string): Promise<UserGroupDetail> {
     return apiClient.get<UserGroupDetail>(`/groups/${id}`);
   },
 
-  async create(data: { name: string; description?: string }): Promise<UserGroup> {
+  async create(data: { name: string; description?: string; sharing_policy?: SharingPolicy }): Promise<UserGroup> {
     return apiClient.post<UserGroup>('/groups', data);
   },
 
-  async update(id: string, data: { name?: string; description?: string }): Promise<UserGroup> {
+  async update(id: string, data: { name?: string; description?: string; sharing_policy?: SharingPolicy }): Promise<UserGroup> {
     return apiClient.patch<UserGroup>(`/groups/${id}`, data);
   },
 
@@ -28,5 +28,9 @@ export const groupsApi = {
 
   async removeMember(groupId: string, userId: string): Promise<void> {
     return apiClient.delete(`/groups/${groupId}/members/${userId}`);
+  },
+
+  async getSettings(): Promise<{ allow_user_group_creation: boolean }> {
+    return apiClient.get('/settings/groups');
   },
 };

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -36,4 +36,12 @@ export const settingsApi = {
   async updateAudioSettings(keepAudioEnabled: boolean): Promise<AudioSettings> {
     return apiClient.put<AudioSettings>('/settings/audio', { keep_audio_enabled: keepAudioEnabled });
   },
+
+  async getGroupsSettings(): Promise<{ allow_user_group_creation: boolean }> {
+    return apiClient.get('/settings/groups');
+  },
+
+  async updateGroupsSettings(allowUserGroupCreation: boolean): Promise<{ allow_user_group_creation: boolean }> {
+    return apiClient.put('/settings/groups', { allow_user_group_creation: allowUserGroupCreation });
+  },
 };

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   FolderOpen,
   MessageSquare,
   Shield,
+  Users,
   ChevronLeft,
   ChevronRight,
   X,
@@ -56,6 +57,7 @@ export function Sidebar() {
     { path: '/upload', label: 'Upload', icon: Upload },
     { path: '/transcriptions', label: 'Transcriptions', icon: FileText },
     { path: '/collections', label: 'Collections', icon: FolderOpen },
+    { path: '/groups', label: 'My Groups', icon: Users },
     { path: '/chat', label: 'Chat', icon: MessageSquare },
   ];
 

--- a/frontend/src/pages/MyGroups.tsx
+++ b/frontend/src/pages/MyGroups.tsx
@@ -33,6 +33,7 @@ export function MyGroups() {
   const [newGroupName, setNewGroupName] = useState('');
   const [newGroupDesc, setNewGroupDesc] = useState('');
   const [newGroupPolicy, setNewGroupPolicy] = useState<SharingPolicy>('creator_only');
+  const [modalError, setModalError] = useState<string | null>(null);
 
   const loadGroups = useCallback(async () => {
     try {
@@ -79,6 +80,7 @@ export function MyGroups() {
 
   const handleCreateGroup = async () => {
     if (!newGroupName.trim()) return;
+    setModalError(null);
     try {
       await groupsApi.create({
         name: newGroupName,
@@ -90,13 +92,14 @@ export function MyGroups() {
       setNewGroupDesc('');
       setNewGroupPolicy('creator_only');
       await loadGroups();
-    } catch {
-      // ignore
+    } catch (err) {
+      setModalError(err instanceof Error ? err.message : 'Failed to create group');
     }
   };
 
   const handleUpdateGroup = async () => {
     if (!editingGroup) return;
+    setModalError(null);
     try {
       await groupsApi.update(editingGroup.id, {
         name: newGroupName,
@@ -108,8 +111,8 @@ export function MyGroups() {
       if (expandedGroupId === editingGroup.id) {
         await loadGroupDetail(editingGroup.id);
       }
-    } catch {
-      // ignore
+    } catch (err) {
+      setModalError(err instanceof Error ? err.message : 'Failed to update group');
     }
   };
 
@@ -239,6 +242,7 @@ export function MyGroups() {
                   setNewGroupName(group.name);
                   setNewGroupDesc(group.description || '');
                   setNewGroupPolicy(group.sharing_policy);
+                  setModalError(null);
                 }}
                 className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                 title="Edit group"
@@ -369,7 +373,7 @@ export function MyGroups() {
             </div>
             {canCreate && (
               <button
-                onClick={() => { setShowCreateModal(true); setNewGroupName(''); setNewGroupDesc(''); setNewGroupPolicy('creator_only'); }}
+                onClick={() => { setShowCreateModal(true); setNewGroupName(''); setNewGroupDesc(''); setNewGroupPolicy('creator_only'); setModalError(null); }}
                 className="flex items-center gap-2 px-4 py-2 bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition-colors text-sm font-medium"
               >
                 <Plus className="w-4 h-4" />
@@ -419,6 +423,11 @@ export function MyGroups() {
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
               {editingGroup ? 'Edit Group' : 'New Group'}
             </h2>
+            {modalError && (
+              <div className="mb-4 px-3 py-2 rounded-lg text-sm bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800">
+                {modalError}
+              </div>
+            )}
             <div className="space-y-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
@@ -480,7 +489,7 @@ export function MyGroups() {
             </div>
             <div className="flex justify-end gap-3 mt-6">
               <button
-                onClick={() => { setShowCreateModal(false); setEditingGroup(null); }}
+                onClick={() => { setShowCreateModal(false); setEditingGroup(null); setModalError(null); }}
                 className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
               >
                 Cancel

--- a/frontend/src/pages/MyGroups.tsx
+++ b/frontend/src/pages/MyGroups.tsx
@@ -1,0 +1,501 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Layout } from '@/components/Layout';
+import { groupsApi } from '@/api/groups';
+import { apiClient } from '@/api/client';
+import {
+  Users,
+  Plus,
+  Trash2,
+  Edit2,
+  Search,
+  UserPlus,
+  X,
+  ChevronRight,
+  ChevronDown,
+  Crown,
+  Lock,
+  Unlock,
+} from 'lucide-react';
+import type { UserGroup, UserGroupDetail, User, SharingPolicy } from '@/types';
+
+export function MyGroups() {
+  const [myGroups, setMyGroups] = useState<UserGroup[]>([]);
+  const [memberGroups, setMemberGroups] = useState<UserGroup[]>([]);
+  const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
+  const [expandedGroup, setExpandedGroup] = useState<UserGroupDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [canCreate, setCanCreate] = useState(false);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [editingGroup, setEditingGroup] = useState<UserGroup | null>(null);
+  const [showAddMember, setShowAddMember] = useState<string | null>(null);
+  const [memberSearchQuery, setMemberSearchQuery] = useState('');
+  const [memberSearchResults, setMemberSearchResults] = useState<User[]>([]);
+  const [newGroupName, setNewGroupName] = useState('');
+  const [newGroupDesc, setNewGroupDesc] = useState('');
+  const [newGroupPolicy, setNewGroupPolicy] = useState<SharingPolicy>('creator_only');
+
+  const loadGroups = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [all, owned, settings] = await Promise.all([
+        groupsApi.list(false),
+        groupsApi.list(true),
+        groupsApi.getSettings(),
+      ]);
+      setCanCreate(settings.allow_user_group_creation);
+      setMyGroups(owned);
+      // Member-only groups = in all but not in owned
+      const ownedIds = new Set(owned.map((g) => g.id));
+      setMemberGroups(all.filter((g) => !ownedIds.has(g.id)));
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadGroups();
+  }, [loadGroups]);
+
+  const loadGroupDetail = async (groupId: string) => {
+    try {
+      const detail = await groupsApi.get(groupId);
+      setExpandedGroup(detail);
+    } catch {
+      // ignore
+    }
+  };
+
+  const toggleGroup = (groupId: string) => {
+    if (expandedGroupId === groupId) {
+      setExpandedGroupId(null);
+      setExpandedGroup(null);
+    } else {
+      setExpandedGroupId(groupId);
+      loadGroupDetail(groupId);
+    }
+  };
+
+  const handleCreateGroup = async () => {
+    if (!newGroupName.trim()) return;
+    try {
+      await groupsApi.create({
+        name: newGroupName,
+        description: newGroupDesc || undefined,
+        sharing_policy: newGroupPolicy,
+      });
+      setShowCreateModal(false);
+      setNewGroupName('');
+      setNewGroupDesc('');
+      setNewGroupPolicy('creator_only');
+      await loadGroups();
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleUpdateGroup = async () => {
+    if (!editingGroup) return;
+    try {
+      await groupsApi.update(editingGroup.id, {
+        name: newGroupName,
+        description: newGroupDesc || undefined,
+        sharing_policy: newGroupPolicy,
+      });
+      setEditingGroup(null);
+      await loadGroups();
+      if (expandedGroupId === editingGroup.id) {
+        await loadGroupDetail(editingGroup.id);
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleDeleteGroup = async (groupId: string) => {
+    if (!window.confirm('Delete this group? This will also remove all shares to this group.')) return;
+    try {
+      await groupsApi.delete(groupId);
+      if (expandedGroupId === groupId) {
+        setExpandedGroupId(null);
+        setExpandedGroup(null);
+      }
+      await loadGroups();
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleAddMember = async (groupId: string, userId: string) => {
+    try {
+      const updated = await groupsApi.addMember(groupId, userId);
+      setExpandedGroup(updated);
+      setShowAddMember(null);
+      setMemberSearchQuery('');
+      setMemberSearchResults([]);
+      await loadGroups();
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleRemoveMember = async (groupId: string, userId: string) => {
+    try {
+      await groupsApi.removeMember(groupId, userId);
+      await loadGroupDetail(groupId);
+      await loadGroups();
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleToggleSharingPolicy = async (group: UserGroup) => {
+    const newPolicy: SharingPolicy =
+      group.sharing_policy === 'creator_only' ? 'members_allowed' : 'creator_only';
+    try {
+      await groupsApi.update(group.id, { sharing_policy: newPolicy });
+      await loadGroups();
+    } catch {
+      // ignore
+    }
+  };
+
+  useEffect(() => {
+    if (!memberSearchQuery || memberSearchQuery.length < 2) {
+      setMemberSearchResults([]);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      try {
+        const results = await apiClient.get<User[]>(
+          `/users/search?q=${encodeURIComponent(memberSearchQuery)}&limit=5`
+        );
+        setMemberSearchResults(results);
+      } catch {
+        setMemberSearchResults([]);
+      }
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [memberSearchQuery]);
+
+  const GroupCard = ({ group, isOwned }: { group: UserGroup; isOwned: boolean }) => (
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <div
+        className="flex items-center justify-between p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+        onClick={() => toggleGroup(group.id)}
+      >
+        <div className="flex items-center gap-3">
+          {expandedGroupId === group.id
+            ? <ChevronDown className="w-4 h-4 text-gray-400" />
+            : <ChevronRight className="w-4 h-4 text-gray-400" />}
+          <div className="w-10 h-10 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
+            <Users className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+          </div>
+          <div>
+            <div className="flex items-center gap-2 flex-wrap">
+              <h3 className="font-medium text-gray-900 dark:text-white">{group.name}</h3>
+              {isOwned && (
+                <span className="flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">
+                  <Crown className="w-3 h-3" /> Owner
+                </span>
+              )}
+              {isOwned && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); handleToggleSharingPolicy(group); }}
+                  title={
+                    group.sharing_policy === 'creator_only'
+                      ? 'Only you can share to this group — click to allow members'
+                      : 'Members can share to this group — click to restrict to owner only'
+                  }
+                  className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                    group.sharing_policy === 'creator_only'
+                      ? 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200'
+                      : 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 hover:bg-green-200'
+                  }`}
+                >
+                  {group.sharing_policy === 'creator_only'
+                    ? <><Lock className="w-3 h-3" /> Owner only</>
+                    : <><Unlock className="w-3 h-3" /> Members can share</>}
+                </button>
+              )}
+            </div>
+            {group.description && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">{group.description}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            {group.member_count} member{group.member_count !== 1 ? 's' : ''}
+          </span>
+          {isOwned && (
+            <>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setEditingGroup(group);
+                  setNewGroupName(group.name);
+                  setNewGroupDesc(group.description || '');
+                  setNewGroupPolicy(group.sharing_policy);
+                }}
+                className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                title="Edit group"
+              >
+                <Edit2 className="w-4 h-4" />
+              </button>
+              <button
+                onClick={(e) => { e.stopPropagation(); handleDeleteGroup(group.id); }}
+                className="p-1.5 text-gray-400 hover:text-red-500 transition-colors"
+                title="Delete group"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded detail */}
+      {expandedGroupId === group.id && expandedGroup && (
+        <div className="border-t border-gray-200 dark:border-gray-700 p-4">
+          <div className="flex items-center justify-between mb-3">
+            <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">Members</h4>
+            {isOwned && (
+              <button
+                onClick={() => {
+                  setShowAddMember(group.id);
+                  setMemberSearchQuery('');
+                  setMemberSearchResults([]);
+                }}
+                className="flex items-center gap-1 text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700"
+              >
+                <UserPlus className="w-4 h-4" />
+                Add Member
+              </button>
+            )}
+          </div>
+
+          {showAddMember === group.id && (
+            <div className="mb-3 relative">
+              <div className="flex items-center gap-2 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700">
+                <Search className="w-4 h-4 text-gray-400" />
+                <input
+                  type="text"
+                  placeholder="Search users..."
+                  value={memberSearchQuery}
+                  onChange={(e) => setMemberSearchQuery(e.target.value)}
+                  className="flex-1 bg-transparent text-sm outline-none text-gray-900 dark:text-white placeholder-gray-400"
+                  autoFocus
+                />
+                <button onClick={() => setShowAddMember(null)} className="text-gray-400 hover:text-gray-600">
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+              {memberSearchResults.length > 0 && (
+                <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg z-10 max-h-40 overflow-y-auto">
+                  {memberSearchResults.map((user) => (
+                    <button
+                      key={user.id}
+                      onClick={() => handleAddMember(group.id, user.id)}
+                      className="w-full flex items-center gap-2 px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-600 text-left text-sm"
+                    >
+                      <span className="font-medium text-gray-900 dark:text-white">
+                        {user.display_name || user.email}
+                      </span>
+                      <span className="text-gray-400 text-xs">{user.email}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {expandedGroup.members.length === 0 ? (
+            <p className="text-sm text-gray-400 italic">No members yet</p>
+          ) : (
+            <div className="space-y-2">
+              {expandedGroup.members.map((member) => (
+                <div key={member.id} className="flex items-center justify-between px-3 py-2 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                  <div className="flex items-center gap-2">
+                    <div className="w-7 h-7 rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center">
+                      <span className="text-xs font-medium text-primary-600 dark:text-primary-400">
+                        {(member.display_name || member.email).charAt(0).toUpperCase()}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-sm font-medium text-gray-900 dark:text-white">
+                        {member.display_name || member.email}
+                      </span>
+                      {member.display_name && (
+                        <span className="text-xs text-gray-400">{member.email}</span>
+                      )}
+                      {member.id === group.owner_id && (
+                        <Crown className="w-3.5 h-3.5 text-amber-500" title="Group owner" />
+                      )}
+                    </div>
+                  </div>
+                  {isOwned && member.id !== group.owner_id && (
+                    <button
+                      onClick={() => handleRemoveMember(group.id, member.id)}
+                      className="p-1 text-gray-400 hover:text-red-500 transition-colors"
+                      title="Remove member"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <Layout title="My Groups">
+      <div className="max-w-4xl mx-auto space-y-8">
+
+        {/* My Groups (owned) */}
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white">My Groups</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                Groups you own — invite members and control sharing permissions.
+              </p>
+            </div>
+            {canCreate && (
+              <button
+                onClick={() => { setShowCreateModal(true); setNewGroupName(''); setNewGroupDesc(''); setNewGroupPolicy('creator_only'); }}
+                className="flex items-center gap-2 px-4 py-2 bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition-colors text-sm font-medium"
+              >
+                <Plus className="w-4 h-4" />
+                New Group
+              </button>
+            )}
+          </div>
+
+          {loading ? (
+            <div className="text-center py-8 text-gray-500">Loading...</div>
+          ) : myGroups.length === 0 ? (
+            <div className="text-center py-8 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">
+              <Users className="w-10 h-10 text-gray-300 mx-auto mb-2" />
+              <p className="text-gray-500 text-sm">
+                {canCreate
+                  ? "You haven't created any groups yet."
+                  : 'Group creation is managed by your administrator.'}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {myGroups.map((g) => <GroupCard key={g.id} group={g} isOwned />)}
+            </div>
+          )}
+        </div>
+
+        {/* Groups I'm a member of */}
+        {memberGroups.length > 0 && (
+          <div>
+            <div className="mb-4">
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white">Member Of</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                Groups you belong to.
+              </p>
+            </div>
+            <div className="space-y-3">
+              {memberGroups.map((g) => <GroupCard key={g.id} group={g} isOwned={false} />)}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Create / Edit Modal */}
+      {(showCreateModal || editingGroup) && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-md p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+              {editingGroup ? 'Edit Group' : 'New Group'}
+            </h2>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
+                <input
+                  type="text"
+                  value={newGroupName}
+                  onChange={(e) => setNewGroupName(e.target.value)}
+                  placeholder="e.g. My Team"
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm"
+                  autoFocus
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Description (optional)
+                </label>
+                <textarea
+                  value={newGroupDesc}
+                  onChange={(e) => setNewGroupDesc(e.target.value)}
+                  placeholder="What is this group for?"
+                  rows={2}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm resize-none"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Sharing policy
+                </label>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setNewGroupPolicy('creator_only')}
+                    className={`flex-1 flex items-center gap-2 px-3 py-2 rounded-lg border text-sm transition-colors ${
+                      newGroupPolicy === 'creator_only'
+                        ? 'border-amber-400 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300'
+                        : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400'
+                    }`}
+                  >
+                    <Lock className="w-4 h-4" /> Only me
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setNewGroupPolicy('members_allowed')}
+                    className={`flex-1 flex items-center gap-2 px-3 py-2 rounded-lg border text-sm transition-colors ${
+                      newGroupPolicy === 'members_allowed'
+                        ? 'border-green-400 bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300'
+                        : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400'
+                    }`}
+                  >
+                    <Unlock className="w-4 h-4" /> Members can share
+                  </button>
+                </div>
+                <p className="text-xs text-gray-400 mt-1">
+                  {newGroupPolicy === 'creator_only'
+                    ? 'Only you can share resources to this group.'
+                    : 'Any member can share resources to this group.'}
+                </p>
+              </div>
+            </div>
+            <div className="flex justify-end gap-3 mt-6">
+              <button
+                onClick={() => { setShowCreateModal(false); setEditingGroup(null); }}
+                className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={editingGroup ? handleUpdateGroup : handleCreateGroup}
+                disabled={!newGroupName.trim()}
+                className="px-4 py-2 text-sm bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition-colors font-medium disabled:opacity-50"
+              >
+                {editingGroup ? 'Update' : 'Create'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+}

--- a/frontend/src/pages/admin/AdminPanel.tsx
+++ b/frontend/src/pages/admin/AdminPanel.tsx
@@ -9,6 +9,7 @@ import {
   Plug,
   KeyRound,
   Mail,
+  SlidersHorizontal,
 } from 'lucide-react';
 
 import { Templates } from './Templates';
@@ -16,10 +17,11 @@ import { Users } from './Users';
 import { Groups } from './Groups';
 import { RegistrationSettingsPage } from './RegistrationSettings';
 import { ApiSettings } from './ApiSettings';
+import { FeatureSettings } from './FeatureSettings';
 import { OIDCSettings } from './OIDCSettings';
 import { EmailSettings } from './EmailSettings';
 
-type AdminTab = 'users' | 'groups' | 'templates' | 'registration' | 'sso' | 'email' | 'api';
+type AdminTab = 'users' | 'groups' | 'templates' | 'registration' | 'sso' | 'email' | 'features' | 'api';
 
 const tabs: { key: AdminTab; label: string; icon: typeof Shield }[] = [
   { key: 'users', label: 'Users', icon: Shield },
@@ -28,6 +30,7 @@ const tabs: { key: AdminTab; label: string; icon: typeof Shield }[] = [
   { key: 'registration', label: 'Registration', icon: UserPlus },
   { key: 'sso', label: 'SSO / OIDC', icon: KeyRound },
   { key: 'email', label: 'Email', icon: Mail },
+  { key: 'features', label: 'Features', icon: SlidersHorizontal },
   { key: 'api', label: 'API Settings', icon: Plug },
 ];
 
@@ -57,6 +60,8 @@ export function AdminPanel() {
         return <OIDCSettings embedded />;
       case 'email':
         return <EmailSettings embedded />;
+      case 'features':
+        return <FeatureSettings embedded />;
       case 'api':
         return <ApiSettings embedded />;
       default:

--- a/frontend/src/pages/admin/ApiSettings.tsx
+++ b/frontend/src/pages/admin/ApiSettings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Layout } from '@/components/Layout';
 import { settingsApi, AppSetting } from '@/api/settings';
-import { Save, RotateCcw, Loader, CheckCircle, AlertCircle, Server, Fingerprint, Users } from 'lucide-react';
+import { Save, RotateCcw, Loader, CheckCircle, AlertCircle } from 'lucide-react';
 
 const VAD_MODE_OPTIONS = [
   { value: 'silero', label: 'Silero — Fast, lightweight VAD' },
@@ -65,92 +65,10 @@ export function ApiSettings({ embedded }: { embedded?: boolean }) {
   const [isLoading, setIsLoading] = useState(true);
   const [saving, setSaving] = useState<string | null>(null);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
-  const [keepAudioEnabled, setKeepAudioEnabled] = useState(true);
-  const [savingAudio, setSavingAudio] = useState(false);
-  const [voiceFingerprintingEnabled, setVoiceFingerprintingEnabled] = useState(false);
-  const [savingVoice, setSavingVoice] = useState(false);
-  const [allowUserGroupCreation, setAllowUserGroupCreation] = useState(false);
-  const [savingGroups, setSavingGroups] = useState(false);
 
   useEffect(() => {
     loadSettings();
-    loadAudioSettings();
-    loadVoiceFingerprintingSetting();
-    loadGroupsSettings();
   }, []);
-
-  const loadAudioSettings = async () => {
-    try {
-      const data = await settingsApi.getAudioSettings();
-      setKeepAudioEnabled(data.keep_audio_enabled);
-    } catch (error) {
-      console.error('Failed to load audio settings:', error);
-    }
-  };
-
-  const loadVoiceFingerprintingSetting = async () => {
-    try {
-      const data = await settingsApi.getSettings();
-      const setting = data.find((s) => s.key === 'voice_fingerprinting_enabled');
-      setVoiceFingerprintingEnabled(setting?.value?.toLowerCase() === 'true');
-    } catch (error) {
-      console.error('Failed to load voice fingerprinting setting:', error);
-    }
-  };
-
-  const handleToggleVoiceFingerprinting = async () => {
-    setSavingVoice(true);
-    try {
-      const newValue = !voiceFingerprintingEnabled;
-      await settingsApi.updateSetting('voice_fingerprinting_enabled', newValue ? 'true' : 'false');
-      setVoiceFingerprintingEnabled(newValue);
-      setMessage({
-        type: 'success',
-        text: `Voice fingerprinting ${newValue ? 'enabled' : 'disabled'}`,
-      });
-    } catch (error) {
-      setMessage({ type: 'error', text: 'Failed to update voice fingerprinting setting' });
-    } finally {
-      setSavingVoice(false);
-    }
-  };
-
-  const loadGroupsSettings = async () => {
-    try {
-      const data = await settingsApi.getGroupsSettings();
-      setAllowUserGroupCreation(data.allow_user_group_creation);
-    } catch {
-      // ignore
-    }
-  };
-
-  const handleToggleUserGroupCreation = async () => {
-    setSavingGroups(true);
-    try {
-      const newValue = !allowUserGroupCreation;
-      await settingsApi.updateGroupsSettings(newValue);
-      setAllowUserGroupCreation(newValue);
-      setMessage({ type: 'success', text: `User group creation ${newValue ? 'enabled' : 'disabled'}` });
-    } catch {
-      setMessage({ type: 'error', text: 'Failed to update group creation setting' });
-    } finally {
-      setSavingGroups(false);
-    }
-  };
-
-  const handleToggleKeepAudio = async () => {
-    setSavingAudio(true);
-    try {
-      const newValue = !keepAudioEnabled;
-      await settingsApi.updateAudioSettings(newValue);
-      setKeepAudioEnabled(newValue);
-      setMessage({ type: 'success', text: `Keep audio ${newValue ? 'enabled' : 'disabled'}` });
-    } catch (error) {
-      setMessage({ type: 'error', text: 'Failed to update audio setting' });
-    } finally {
-      setSavingAudio(false);
-    }
-  };
 
   const loadSettings = async () => {
     setIsLoading(true);
@@ -393,118 +311,6 @@ export function ApiSettings({ embedded }: { embedded?: boolean }) {
             'llm_model',
             'llm_system_prompt',
           ])}
-
-          {/* Audio Storage Settings */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-            <div className="flex items-center gap-2 mb-4">
-              <Server className="w-5 h-5 text-gray-500" />
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Audio Storage</h3>
-            </div>
-            <div className="space-y-4">
-              <div>
-                <div className="flex items-center justify-between">
-                  <div>
-                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                      Allow users to keep audio
-                    </label>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                      When enabled, users can choose to save audio files on the server alongside their transcriptions.
-                      When disabled, audio is always deleted after transcription completes.
-                    </p>
-                  </div>
-                  <button
-                    onClick={handleToggleKeepAudio}
-                    disabled={savingAudio}
-                    className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors flex-shrink-0 ml-4 ${
-                      keepAudioEnabled ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
-                    } ${savingAudio ? 'opacity-50' : ''}`}
-                  >
-                    <span
-                      className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${
-                        keepAudioEnabled ? 'translate-x-7' : 'translate-x-1'
-                      }`}
-                    />
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Voice Fingerprinting Settings */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-            <div className="flex items-center gap-2 mb-4">
-              <Fingerprint className="w-5 h-5 text-gray-500" />
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-                Voice Fingerprinting
-              </h3>
-            </div>
-            <div className="space-y-4">
-              <div>
-                <div className="flex items-center justify-between">
-                  <div>
-                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                      Enable voice fingerprinting
-                    </label>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                      When enabled, users can record their voice to create a speaker profile.
-                      During transcription, speakers are automatically identified by matching
-                      against known profiles. Voice embeddings are encrypted at rest. Disabling
-                      this hides the feature from all users but does not delete existing profiles.
-                    </p>
-                  </div>
-                  <button
-                    onClick={handleToggleVoiceFingerprinting}
-                    disabled={savingVoice}
-                    className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors flex-shrink-0 ml-4 ${
-                      voiceFingerprintingEnabled ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
-                    } ${savingVoice ? 'opacity-50' : ''}`}
-                  >
-                    <span
-                      className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${
-                        voiceFingerprintingEnabled ? 'translate-x-7' : 'translate-x-1'
-                      }`}
-                    />
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Groups Settings */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-            <div className="flex items-center gap-2 mb-4">
-              <Users className="w-5 h-5 text-gray-500" />
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Groups</h3>
-            </div>
-            <div className="space-y-4">
-              <div>
-                <div className="flex items-center justify-between">
-                  <div>
-                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                      Allow users to create groups
-                    </label>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                      When enabled, regular users can create their own groups and invite members.
-                      Admins can always create groups regardless of this setting.
-                    </p>
-                  </div>
-                  <button
-                    onClick={handleToggleUserGroupCreation}
-                    disabled={savingGroups}
-                    className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors flex-shrink-0 ml-4 ${
-                      allowUserGroupCreation ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
-                    } ${savingGroups ? 'opacity-50' : ''}`}
-                  >
-                    <span
-                      className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${
-                        allowUserGroupCreation ? 'translate-x-7' : 'translate-x-1'
-                      }`}
-                    />
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
 
           <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
             <p className="text-sm text-gray-600 dark:text-gray-400">

--- a/frontend/src/pages/admin/ApiSettings.tsx
+++ b/frontend/src/pages/admin/ApiSettings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Layout } from '@/components/Layout';
 import { settingsApi, AppSetting } from '@/api/settings';
-import { Save, RotateCcw, Loader, CheckCircle, AlertCircle, Server, Fingerprint } from 'lucide-react';
+import { Save, RotateCcw, Loader, CheckCircle, AlertCircle, Server, Fingerprint, Users } from 'lucide-react';
 
 const VAD_MODE_OPTIONS = [
   { value: 'silero', label: 'Silero — Fast, lightweight VAD' },
@@ -69,11 +69,14 @@ export function ApiSettings({ embedded }: { embedded?: boolean }) {
   const [savingAudio, setSavingAudio] = useState(false);
   const [voiceFingerprintingEnabled, setVoiceFingerprintingEnabled] = useState(false);
   const [savingVoice, setSavingVoice] = useState(false);
+  const [allowUserGroupCreation, setAllowUserGroupCreation] = useState(false);
+  const [savingGroups, setSavingGroups] = useState(false);
 
   useEffect(() => {
     loadSettings();
     loadAudioSettings();
     loadVoiceFingerprintingSetting();
+    loadGroupsSettings();
   }, []);
 
   const loadAudioSettings = async () => {
@@ -109,6 +112,29 @@ export function ApiSettings({ embedded }: { embedded?: boolean }) {
       setMessage({ type: 'error', text: 'Failed to update voice fingerprinting setting' });
     } finally {
       setSavingVoice(false);
+    }
+  };
+
+  const loadGroupsSettings = async () => {
+    try {
+      const data = await settingsApi.getGroupsSettings();
+      setAllowUserGroupCreation(data.allow_user_group_creation);
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleToggleUserGroupCreation = async () => {
+    setSavingGroups(true);
+    try {
+      const newValue = !allowUserGroupCreation;
+      await settingsApi.updateGroupsSettings(newValue);
+      setAllowUserGroupCreation(newValue);
+      setMessage({ type: 'success', text: `User group creation ${newValue ? 'enabled' : 'disabled'}` });
+    } catch {
+      setMessage({ type: 'error', text: 'Failed to update group creation setting' });
+    } finally {
+      setSavingGroups(false);
     }
   };
 
@@ -436,6 +462,42 @@ export function ApiSettings({ embedded }: { embedded?: boolean }) {
                     <span
                       className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${
                         voiceFingerprintingEnabled ? 'translate-x-7' : 'translate-x-1'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Groups Settings */}
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+            <div className="flex items-center gap-2 mb-4">
+              <Users className="w-5 h-5 text-gray-500" />
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Groups</h3>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Allow users to create groups
+                    </label>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                      When enabled, regular users can create their own groups and invite members.
+                      Admins can always create groups regardless of this setting.
+                    </p>
+                  </div>
+                  <button
+                    onClick={handleToggleUserGroupCreation}
+                    disabled={savingGroups}
+                    className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors flex-shrink-0 ml-4 ${
+                      allowUserGroupCreation ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
+                    } ${savingGroups ? 'opacity-50' : ''}`}
+                  >
+                    <span
+                      className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${
+                        allowUserGroupCreation ? 'translate-x-7' : 'translate-x-1'
                       }`}
                     />
                   </button>

--- a/frontend/src/pages/admin/FeatureSettings.tsx
+++ b/frontend/src/pages/admin/FeatureSettings.tsx
@@ -1,0 +1,221 @@
+import { useState, useEffect } from 'react';
+import { Layout } from '@/components/Layout';
+import { settingsApi } from '@/api/settings';
+import { Server, Fingerprint, Users, CheckCircle, AlertCircle } from 'lucide-react';
+
+export function FeatureSettings({ embedded }: { embedded?: boolean }) {
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  // Audio
+  const [keepAudioEnabled, setKeepAudioEnabled] = useState(true);
+  const [savingAudio, setSavingAudio] = useState(false);
+
+  // Voice fingerprinting
+  const [voiceFingerprintingEnabled, setVoiceFingerprintingEnabled] = useState(false);
+  const [savingVoice, setSavingVoice] = useState(false);
+
+  // Groups
+  const [allowUserGroupCreation, setAllowUserGroupCreation] = useState(false);
+  const [savingGroups, setSavingGroups] = useState(false);
+
+  useEffect(() => {
+    loadAudio();
+    loadVoiceFingerprinting();
+    loadGroups();
+  }, []);
+
+  const loadAudio = async () => {
+    try {
+      const data = await settingsApi.getAudioSettings();
+      setKeepAudioEnabled(data.keep_audio_enabled);
+    } catch {
+      // ignore
+    }
+  };
+
+  const loadVoiceFingerprinting = async () => {
+    try {
+      const data = await settingsApi.getSettings();
+      const setting = data.find((s) => s.key === 'voice_fingerprinting_enabled');
+      setVoiceFingerprintingEnabled(setting?.value?.toLowerCase() === 'true');
+    } catch {
+      // ignore
+    }
+  };
+
+  const loadGroups = async () => {
+    try {
+      const data = await settingsApi.getGroupsSettings();
+      setAllowUserGroupCreation(data.allow_user_group_creation);
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleToggleKeepAudio = async () => {
+    setSavingAudio(true);
+    try {
+      const newValue = !keepAudioEnabled;
+      await settingsApi.updateAudioSettings(newValue);
+      setKeepAudioEnabled(newValue);
+      setMessage({ type: 'success', text: `Keep audio ${newValue ? 'enabled' : 'disabled'}` });
+    } catch {
+      setMessage({ type: 'error', text: 'Failed to update audio setting' });
+    } finally {
+      setSavingAudio(false);
+    }
+  };
+
+  const handleToggleVoiceFingerprinting = async () => {
+    setSavingVoice(true);
+    try {
+      const newValue = !voiceFingerprintingEnabled;
+      await settingsApi.updateSetting('voice_fingerprinting_enabled', newValue ? 'true' : 'false');
+      setVoiceFingerprintingEnabled(newValue);
+      setMessage({
+        type: 'success',
+        text: `Voice fingerprinting ${newValue ? 'enabled' : 'disabled'}`,
+      });
+    } catch {
+      setMessage({ type: 'error', text: 'Failed to update voice fingerprinting setting' });
+    } finally {
+      setSavingVoice(false);
+    }
+  };
+
+  const handleToggleUserGroupCreation = async () => {
+    setSavingGroups(true);
+    try {
+      const newValue = !allowUserGroupCreation;
+      await settingsApi.updateGroupsSettings(newValue);
+      setAllowUserGroupCreation(newValue);
+      setMessage({
+        type: 'success',
+        text: `User group creation ${newValue ? 'enabled' : 'disabled'}`,
+      });
+    } catch {
+      setMessage({ type: 'error', text: 'Failed to update group creation setting' });
+    } finally {
+      setSavingGroups(false);
+    }
+  };
+
+  const Toggle = ({
+    enabled,
+    onClick,
+    disabled,
+  }: {
+    enabled: boolean;
+    onClick: () => void;
+    disabled?: boolean;
+  }) => (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors flex-shrink-0 ml-4 ${
+        enabled ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
+      } ${disabled ? 'opacity-50' : ''}`}
+    >
+      <span
+        className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${
+          enabled ? 'translate-x-7' : 'translate-x-1'
+        }`}
+      />
+    </button>
+  );
+
+  const content = (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      {/* Message banner */}
+      {message && (
+        <div
+          className={`flex items-center gap-2 px-4 py-3 rounded-lg text-sm ${
+            message.type === 'success'
+              ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300 border border-green-200 dark:border-green-800'
+              : 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800'
+          }`}
+        >
+          {message.type === 'success' ? (
+            <CheckCircle className="w-4 h-4" />
+          ) : (
+            <AlertCircle className="w-4 h-4" />
+          )}
+          {message.text}
+        </div>
+      )}
+
+      {/* Audio Storage */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Server className="w-5 h-5 text-gray-500" />
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Audio Storage</h3>
+        </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Allow users to keep audio
+            </label>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              When enabled, users can choose to save audio files on the server alongside their
+              transcriptions. When disabled, audio is always deleted after transcription completes.
+            </p>
+          </div>
+          <Toggle enabled={keepAudioEnabled} onClick={handleToggleKeepAudio} disabled={savingAudio} />
+        </div>
+      </div>
+
+      {/* Voice Fingerprinting */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Fingerprint className="w-5 h-5 text-gray-500" />
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Voice Fingerprinting</h3>
+        </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Enable voice fingerprinting
+            </label>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              When enabled, users can record their voice to create a speaker profile. During
+              transcription, speakers are automatically identified by matching against known
+              profiles. Voice embeddings are encrypted at rest. Disabling this hides the feature
+              from all users but does not delete existing profiles.
+            </p>
+          </div>
+          <Toggle
+            enabled={voiceFingerprintingEnabled}
+            onClick={handleToggleVoiceFingerprinting}
+            disabled={savingVoice}
+          />
+        </div>
+      </div>
+
+      {/* Groups */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Users className="w-5 h-5 text-gray-500" />
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Groups</h3>
+        </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Allow users to create groups
+            </label>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              When enabled, regular users can create their own groups and invite members. Admins
+              can always create groups regardless of this setting.
+            </p>
+          </div>
+          <Toggle
+            enabled={allowUserGroupCreation}
+            onClick={handleToggleUserGroupCreation}
+            disabled={savingGroups}
+          />
+        </div>
+      </div>
+    </div>
+  );
+
+  if (embedded) return content;
+  return <Layout title="Feature Settings">{content}</Layout>;
+}

--- a/frontend/src/pages/admin/Groups.tsx
+++ b/frontend/src/pages/admin/Groups.tsx
@@ -31,6 +31,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
   const [newGroupName, setNewGroupName] = useState('');
   const [newGroupDesc, setNewGroupDesc] = useState('');
   const [newGroupPolicy, setNewGroupPolicy] = useState<SharingPolicy>('creator_only');
+  const [modalError, setModalError] = useState<string | null>(null);
 
   const loadGroups = useCallback(async () => {
     try {
@@ -69,6 +70,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
 
   const handleCreateGroup = async () => {
     if (!newGroupName.trim()) return;
+    setModalError(null);
     try {
       await groupsApi.create({
         name: newGroupName,
@@ -80,13 +82,14 @@ export function Groups({ embedded }: { embedded?: boolean }) {
       setNewGroupDesc('');
       setNewGroupPolicy('creator_only');
       await loadGroups();
-    } catch {
-      // ignore
+    } catch (err) {
+      setModalError(err instanceof Error ? err.message : 'Failed to create group');
     }
   };
 
   const handleUpdateGroup = async () => {
     if (!editingGroup) return;
+    setModalError(null);
     try {
       await groupsApi.update(editingGroup.id, {
         name: newGroupName,
@@ -101,8 +104,8 @@ export function Groups({ embedded }: { embedded?: boolean }) {
       if (expandedGroupId === editingGroup.id) {
         await loadGroupDetail(editingGroup.id);
       }
-    } catch {
-      // ignore
+    } catch (err) {
+      setModalError(err instanceof Error ? err.message : 'Failed to update group');
     }
   };
 
@@ -185,6 +188,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
               setNewGroupName('');
               setNewGroupDesc('');
               setNewGroupPolicy('creator_only');
+              setModalError(null);
             }}
             className="flex items-center gap-2 px-4 py-2 bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition-colors text-sm font-medium"
           >
@@ -259,6 +263,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
                         setNewGroupName(group.name);
                         setNewGroupDesc(group.description || '');
                         setNewGroupPolicy(group.sharing_policy);
+                        setModalError(null);
                       }}
                       className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                     >
@@ -383,6 +388,11 @@ export function Groups({ embedded }: { embedded?: boolean }) {
               <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
                 {editingGroup ? 'Edit Group' : 'New Group'}
               </h2>
+              {modalError && (
+                <div className="mb-4 px-3 py-2 rounded-lg text-sm bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800">
+                  {modalError}
+                </div>
+              )}
               <div className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
@@ -446,7 +456,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
               </div>
               <div className="flex justify-end gap-3 mt-6">
                 <button
-                  onClick={() => { setShowCreateModal(false); setEditingGroup(null); }}
+                  onClick={() => { setShowCreateModal(false); setEditingGroup(null); setModalError(null); }}
                   className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
                 >
                   Cancel

--- a/frontend/src/pages/admin/Groups.tsx
+++ b/frontend/src/pages/admin/Groups.tsx
@@ -12,8 +12,11 @@ import {
   X,
   ChevronRight,
   ChevronDown,
+  Crown,
+  Lock,
+  Unlock,
 } from 'lucide-react';
-import type { UserGroup, UserGroupDetail, User } from '@/types';
+import type { UserGroup, UserGroupDetail, User, SharingPolicy } from '@/types';
 
 export function Groups({ embedded }: { embedded?: boolean }) {
   const [groups, setGroups] = useState<UserGroup[]>([]);
@@ -27,6 +30,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
   const [memberSearchResults, setMemberSearchResults] = useState<User[]>([]);
   const [newGroupName, setNewGroupName] = useState('');
   const [newGroupDesc, setNewGroupDesc] = useState('');
+  const [newGroupPolicy, setNewGroupPolicy] = useState<SharingPolicy>('creator_only');
 
   const loadGroups = useCallback(async () => {
     try {
@@ -66,10 +70,15 @@ export function Groups({ embedded }: { embedded?: boolean }) {
   const handleCreateGroup = async () => {
     if (!newGroupName.trim()) return;
     try {
-      await groupsApi.create({ name: newGroupName, description: newGroupDesc || undefined });
+      await groupsApi.create({
+        name: newGroupName,
+        description: newGroupDesc || undefined,
+        sharing_policy: newGroupPolicy,
+      });
       setShowCreateModal(false);
       setNewGroupName('');
       setNewGroupDesc('');
+      setNewGroupPolicy('creator_only');
       await loadGroups();
     } catch {
       // ignore
@@ -82,11 +91,16 @@ export function Groups({ embedded }: { embedded?: boolean }) {
       await groupsApi.update(editingGroup.id, {
         name: newGroupName,
         description: newGroupDesc || undefined,
+        sharing_policy: newGroupPolicy,
       });
       setEditingGroup(null);
       setNewGroupName('');
       setNewGroupDesc('');
+      setNewGroupPolicy('creator_only');
       await loadGroups();
+      if (expandedGroupId === editingGroup.id) {
+        await loadGroupDetail(editingGroup.id);
+      }
     } catch {
       // ignore
     }
@@ -128,7 +142,17 @@ export function Groups({ embedded }: { embedded?: boolean }) {
     }
   };
 
-  // Search users for adding to group
+  const handleToggleSharingPolicy = async (group: UserGroup) => {
+    const newPolicy: SharingPolicy =
+      group.sharing_policy === 'creator_only' ? 'members_allowed' : 'creator_only';
+    try {
+      const updated = await groupsApi.update(group.id, { sharing_policy: newPolicy });
+      setGroups((prev) => prev.map((g) => (g.id === group.id ? updated : g)));
+    } catch {
+      // ignore
+    }
+  };
+
   useEffect(() => {
     if (!memberSearchQuery || memberSearchQuery.length < 2) {
       setMemberSearchResults([]);
@@ -160,6 +184,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
               setShowCreateModal(true);
               setNewGroupName('');
               setNewGroupDesc('');
+              setNewGroupPolicy('creator_only');
             }}
             className="flex items-center gap-2 px-4 py-2 bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition-colors text-sm font-medium"
           >
@@ -197,7 +222,27 @@ export function Groups({ embedded }: { embedded?: boolean }) {
                       <Users className="w-5 h-5 text-blue-600 dark:text-blue-400" />
                     </div>
                     <div>
-                      <h3 className="font-medium text-gray-900 dark:text-white">{group.name}</h3>
+                      <div className="flex items-center gap-2">
+                        <h3 className="font-medium text-gray-900 dark:text-white">{group.name}</h3>
+                        {/* Sharing policy badge */}
+                        <button
+                          onClick={(e) => { e.stopPropagation(); handleToggleSharingPolicy(group); }}
+                          title={
+                            group.sharing_policy === 'creator_only'
+                              ? 'Only owner can share to this group — click to allow members'
+                              : 'Any member can share to this group — click to restrict to owner'
+                          }
+                          className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium transition-colors ${
+                            group.sharing_policy === 'creator_only'
+                              ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 hover:bg-amber-200'
+                              : 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 hover:bg-green-200'
+                          }`}
+                        >
+                          {group.sharing_policy === 'creator_only'
+                            ? <><Lock className="w-3 h-3" /> Owner only</>
+                            : <><Unlock className="w-3 h-3" /> Members can share</>}
+                        </button>
+                      </div>
                       {group.description && (
                         <p className="text-sm text-gray-500 dark:text-gray-400">{group.description}</p>
                       )}
@@ -213,6 +258,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
                         setEditingGroup(group);
                         setNewGroupName(group.name);
                         setNewGroupDesc(group.description || '');
+                        setNewGroupPolicy(group.sharing_policy);
                       }}
                       className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                     >
@@ -234,9 +280,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
                 {expandedGroupId === group.id && expandedGroup && (
                   <div className="border-t border-gray-200 dark:border-gray-700 p-4">
                     <div className="flex items-center justify-between mb-3">
-                      <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                        Members
-                      </h4>
+                      <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">Members</h4>
                       <button
                         onClick={() => {
                           setShowAddMember(group.id);
@@ -250,7 +294,6 @@ export function Groups({ embedded }: { embedded?: boolean }) {
                       </button>
                     </div>
 
-                    {/* Add member search */}
                     {showAddMember === group.id && (
                       <div className="mb-3 relative">
                         <div className="flex items-center gap-2 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700">
@@ -263,10 +306,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
                             className="flex-1 bg-transparent text-sm outline-none text-gray-900 dark:text-white placeholder-gray-400"
                             autoFocus
                           />
-                          <button
-                            onClick={() => setShowAddMember(null)}
-                            className="text-gray-400 hover:text-gray-600"
-                          >
+                          <button onClick={() => setShowAddMember(null)} className="text-gray-400 hover:text-gray-600">
                             <X className="w-4 h-4" />
                           </button>
                         </div>
@@ -289,7 +329,6 @@ export function Groups({ embedded }: { embedded?: boolean }) {
                       </div>
                     )}
 
-                    {/* Members list */}
                     {expandedGroup.members.length === 0 ? (
                       <p className="text-sm text-gray-400 italic">No members yet</p>
                     ) : (
@@ -305,22 +344,27 @@ export function Groups({ embedded }: { embedded?: boolean }) {
                                   {(member.display_name || member.email).charAt(0).toUpperCase()}
                                 </span>
                               </div>
-                              <div>
+                              <div className="flex items-center gap-1.5">
                                 <span className="text-sm font-medium text-gray-900 dark:text-white">
                                   {member.display_name || member.email}
                                 </span>
                                 {member.display_name && (
-                                  <span className="text-xs text-gray-400 ml-2">{member.email}</span>
+                                  <span className="text-xs text-gray-400">{member.email}</span>
+                                )}
+                                {member.id === group.owner_id && (
+                                  <Crown className="w-3.5 h-3.5 text-amber-500" title="Group owner" />
                                 )}
                               </div>
                             </div>
-                            <button
-                              onClick={() => handleRemoveMember(group.id, member.id)}
-                              className="p-1 text-gray-400 hover:text-red-500 transition-colors"
-                              title="Remove member"
-                            >
-                              <Trash2 className="w-3.5 h-3.5" />
-                            </button>
+                            {member.id !== group.owner_id && (
+                              <button
+                                onClick={() => handleRemoveMember(group.id, member.id)}
+                                className="p-1 text-gray-400 hover:text-red-500 transition-colors"
+                                title="Remove member"
+                              >
+                                <Trash2 className="w-3.5 h-3.5" />
+                              </button>
+                            )}
                           </div>
                         ))}
                       </div>
@@ -341,9 +385,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
               </h2>
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    Name
-                  </label>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
                   <input
                     type="text"
                     value={newGroupName}
@@ -365,13 +407,46 @@ export function Groups({ embedded }: { embedded?: boolean }) {
                     className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm resize-none"
                   />
                 </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    Sharing policy
+                  </label>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setNewGroupPolicy('creator_only')}
+                      className={`flex-1 flex items-center gap-2 px-3 py-2 rounded-lg border text-sm transition-colors ${
+                        newGroupPolicy === 'creator_only'
+                          ? 'border-amber-400 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300'
+                          : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-400'
+                      }`}
+                    >
+                      <Lock className="w-4 h-4" />
+                      <span>Owner only</span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setNewGroupPolicy('members_allowed')}
+                      className={`flex-1 flex items-center gap-2 px-3 py-2 rounded-lg border text-sm transition-colors ${
+                        newGroupPolicy === 'members_allowed'
+                          ? 'border-green-400 bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300'
+                          : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-400'
+                      }`}
+                    >
+                      <Unlock className="w-4 h-4" />
+                      <span>Members can share</span>
+                    </button>
+                  </div>
+                  <p className="text-xs text-gray-400 mt-1">
+                    {newGroupPolicy === 'creator_only'
+                      ? 'Only the group owner can share resources to this group.'
+                      : 'Any member can share resources to this group.'}
+                  </p>
+                </div>
               </div>
               <div className="flex justify-end gap-3 mt-6">
                 <button
-                  onClick={() => {
-                    setShowCreateModal(false);
-                    setEditingGroup(null);
-                  }}
+                  onClick={() => { setShowCreateModal(false); setEditingGroup(null); }}
                   className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
                 >
                   Cancel
@@ -379,7 +454,7 @@ export function Groups({ embedded }: { embedded?: boolean }) {
                 <button
                   onClick={editingGroup ? handleUpdateGroup : handleCreateGroup}
                   disabled={!newGroupName.trim()}
-                  className="px-4 py-2 text-sm bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition-colors font-medium"
+                  className="px-4 py-2 text-sm bg-primary-500 text-white rounded-lg hover:bg-primary-600 transition-colors font-medium disabled:opacity-50"
                 >
                   {editingGroup ? 'Update' : 'Create'}
                 </button>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -88,14 +88,19 @@ export interface Transcription {
 }
 
 // Access control types
+export type SharingPolicy = 'creator_only' | 'members_allowed';
+
 export interface UserGroup {
   id: string;
   name: string;
   description: string | null;
   created_by: string;
+  owner_id: string;
+  sharing_policy: SharingPolicy;
   created_at: string;
   updated_at: string;
   member_count: number;
+  is_owner: boolean;
 }
 
 export interface UserGroupDetail extends UserGroup {


### PR DESCRIPTION
## Summary

### Sprint 5 — User-created groups (3.1)
- Add `owner_id` to `UserGroup` model (backfilled from `created_by` via migration 020) so the creator is always the initial owner, independently of `created_by`
- Non-admin users can create groups when the new `allow_user_group_creation` admin setting is enabled; admins always can
- Creator is automatically added as a member of their own group on creation
- Group owners can edit name/description/sharing policy, manage members, and delete their own groups — no longer admin-only
- New `/groups` page ("My Groups") in the sidebar, split into "My Groups" (owned, full management) and "Member Of" (read-only membership view)
- Admin Groups page updated with owner crown badge on members, sharing policy badge with click-to-toggle, and policy selector in create/edit modal

### Sprint 5 — Sharing policy (3.2)
- Add `sharing_policy` enum (`creator_only` / `members_allowed`) to `UserGroup` with migration 020
- `creator_only` (default): only the group owner can share resources to this group
- `members_allowed`: any member of the group can share resources to it
- Policy enforced in the shares router; admins always bypass
- Policy can be toggled inline from the group card without opening the edit modal

### Group name uniqueness
- Group names are globally unique and case-insensitive (`"Offsec"` and `"offsec "` collide) — prevents social engineering where a user creates a group with a well-known name hoping others share sensitive transcriptions to the wrong group
- Migration 021 normalizes existing names (trim + collapse whitespace) and applies a functional unique index on `lower(name)`; existing case-insensitive duplicates are renamed `Name (2)`, `Name (3)`, ...
- Backend returns a friendly 409 with the conflicting name; both frontend modals surface the error inline

### Admin panel: new Features tab
- Move Audio Storage, Voice Fingerprinting, and Groups toggles out of the API Settings tab (which should stay focused on external service configuration) into a new dedicated Features tab

## Test plan

- [ ] Admin creates a group — works regardless of allow_user_group_creation setting
- [ ] User creates a group — blocked when setting is off, succeeds when on
- [ ] Group owner can add/remove members, edit, and delete their group; non-owner member cannot
- [ ] `creator_only` policy: only group owner can share resources to this group; non-owner member gets 403
- [ ] `members_allowed` policy: any group member can share; non-member gets 403
- [ ] Sharing policy toggle on group card updates immediately
- [ ] Try creating `"Offsec"` when it exists as `"offsec"` — 409 shown in modal
- [ ] Try creating `"Offsec "` (trailing space) — treated as `"Offsec"`, collision detected
- [ ] Admin panel Features tab shows Audio Storage, Voice Fingerprinting, and Groups toggles; API Settings tab no longer contains them
- [ ] `alembic upgrade head` — migrations 020 and 021 apply cleanly
