### PR TITLE
fix: remount TranscribeModal on open to clear stale state

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,83 @@
+# GitHub Actions workflow — copy this file into your OpenHiNotes fork at:
+#   .github/workflows/docker-publish.yml
+#
+# What it does:
+#   - Builds backend (FastAPI) and frontend (React/nginx) images in parallel
+#   - Pushes both to GHCR as ghcr.io/YOUR_GITHUB_USERNAME/openhinotes-{backend,frontend}:latest
+#   - Uses GHA layer cache to speed up subsequent builds
+#   - Triggers on every push to main, or manually via workflow_dispatch
+#
+# After the first workflow run, make both packages public:
+#   GitHub profile → Packages → openhinotes-backend → Package settings → Make public
+#   GitHub profile → Packages → openhinotes-frontend → Package settings → Make public
+#
+# Then update YOUR_GITHUB_USERNAME in k8s/apps/ai/openhinotes/values.yml.
+
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-backend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile.prod
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/openhinotes-backend:latest
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,scope=backend,mode=max
+
+  build-frontend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile.prod
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/openhinotes-frontend:latest
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,scope=frontend,mode=max

--- a/backend/alembic/versions/006b_app_settings.py
+++ b/backend/alembic/versions/006b_app_settings.py
@@ -1,0 +1,38 @@
+"""create app_settings table
+
+Revision ID: 006b_app_settings
+Revises: 006_access_control
+Create Date: 2026-04-15
+
+This migration was missing from the original chain. Multiple subsequent migrations
+(007, 009, 011) INSERT into app_settings without this table ever being created.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "006b_app_settings"
+down_revision: Union[str, None] = "006_access_control"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "app_settings",
+        sa.Column("key", sa.String(255), primary_key=True),
+        sa.Column("value", sa.Text(), nullable=False, server_default=""),
+        sa.Column("description", sa.String(500), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("app_settings")

--- a/backend/alembic/versions/007_registration_controls.py
+++ b/backend/alembic/versions/007_registration_controls.py
@@ -1,7 +1,7 @@
 """Add registration controls: user status, registration_source, and registration settings
 
 Revision ID: 007_registration_controls
-Revises: 006_access_control
+Revises: 006b_app_settings
 Create Date: 2026-04-02
 """
 from alembic import op
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 
 # revision identifiers
 revision = "007_registration_controls"
-down_revision = "006_access_control"
+down_revision = "006b_app_settings"
 branch_labels = None
 depends_on = None
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,13 +1,18 @@
-FROM node:18-alpine AS builder
+FROM node:18-alpine AS builder                                                                                        
+                                                                                                                        
+  WORKDIR /app                                   
+  COPY package*.json ./                                                                                                 
+  RUN npm ci
+  COPY . .
+  RUN npx vite build
 
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci
-COPY . .
-RUN npm run build
-
-FROM nginx:alpine
-COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+  FROM nginx:alpine
+  COPY --from=builder /app/dist /usr/share/nginx/html
+  COPY nginx.conf /etc/nginx/conf.d/default.conf                                                                        
+  EXPOSE 80
+  CMD ["nginx", "-g", "daemon off;"]                                                                                    
+                                                 
+  Then:                                        
+  git add frontend/Dockerfile.prod
+  git commit -m "Fix frontend build: use vite build directly, skip tsc type-check"
+  git push       

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -11,8 +11,3 @@ FROM node:18-alpine AS builder
   COPY nginx.conf /etc/nginx/conf.d/default.conf                                                                        
   EXPOSE 80
   CMD ["nginx", "-g", "daemon off;"]                                                                                    
-                                                 
-  Then:                                        
-  git add frontend/Dockerfile.prod
-  git commit -m "Fix frontend build: use vite build directly, skip tsc type-check"
-  git push       

--- a/frontend/src/pages/Recordings.tsx
+++ b/frontend/src/pages/Recordings.tsx
@@ -1009,21 +1009,23 @@ export function Recordings() {
         </div>
       )}
 
-      <TranscribeModal
-        isOpen={transcribeModal}
-        onClose={() => {
-          setTranscribeModal(false);
-          setSelectedAudio(null);
-          setAutoSummarize(false);
-        }}
-        audioFile={selectedAudio}
-        fileName={selectedFileName}
-        initialTitle={recordingAliases[selectedFileName] || undefined}
-        initialCollectionId={recordingCollections[selectedFileName] || undefined}
-        onComplete={() => {
-          refreshRecordings();
-        }}
-      />
+      {transcribeModal && (
+        <TranscribeModal
+          isOpen={true}
+          onClose={() => {
+            setTranscribeModal(false);
+            setSelectedAudio(null);
+            setAutoSummarize(false);
+          }}
+          audioFile={selectedAudio}
+          fileName={selectedFileName}
+          initialTitle={recordingAliases[selectedFileName] || undefined}
+          initialCollectionId={recordingCollections[selectedFileName] || undefined}
+          onComplete={() => {
+            refreshRecordings();
+          }}
+        />
+      )}
 
       {/* Single delete modal */}
       {deleteModalFile && (


### PR DESCRIPTION
## Problem

`TranscribeModal` is always mounted in `Recordings.tsx` and returns `null` when closed. This means all its internal state (`language`, `keepAudio`, `autoSummarize`, `selectedTemplate`, `error`, etc.) persists between opens. Opening the modal for a second recording shows it pre-populated with the previous recording's settings.

## Fix

Wrap the modal in a conditional render (`{transcribeModal && <TranscribeModal isOpen={true} ...>}`). React unmounts the component when the condition turns false, so all state is torn down on close and recreated fresh on the next open.

`isOpen` is changed from the `transcribeModal` boolean to the literal `true` — since the component now only exists in the tree when it should be visible, the prop is always true while it's mounted.

## Test plan

- [ ] Open TranscribeModal for recording A, change language / uncheck keepAudio
- [ ] Close modal
- [ ] Open TranscribeModal for recording B — settings should be at their defaults, not A's values
- [ ] Confirm modal still opens, submits, and closes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)