### PR TITLE
fix: cancel releases processing lock on user cancellation

### DIFF
--- a/backend/app/services/queue.py
+++ b/backend/app/services/queue.py
@@ -296,7 +296,11 @@ class TranscriptionQueue:
             file_path = f"{settings.uploads_directory}/{user_id}/{stored_filename}"
 
             async def on_progress(status_str: str, progress: float, stage: str = None):
-                """Update progress in DB and notify subscribers."""
+                """Update progress in DB and notify subscribers.
+
+                Raises if the transcription was cancelled by the user so the
+                polling loop exits and the processing lock is released promptly.
+                """
                 # Don't forward VoxHub "completed" as a progress event — the
                 # official "completed" event is sent after speaker identification
                 # + DB commit.  Sending it early would cause the frontend to
@@ -306,6 +310,11 @@ class TranscriptionQueue:
                     stage = "finalizing"
 
                 async with AsyncSessionLocal() as db:
+                    row = await db.execute(
+                        select(Transcription.status).where(Transcription.id == transcription_id)
+                    )
+                    if row.scalar_one_or_none() == TranscriptionStatus.cancelled:
+                        raise Exception(f"Transcription {transcription_id} cancelled by user")
                     await db.execute(
                         update(Transcription)
                         .where(Transcription.id == transcription_id)


### PR DESCRIPTION
## Problem

When a user cancels a transcription that is already mid-processing (e.g. VoxHub is running diarization), the `_processing_lock` is held for the full remaining duration of the VoxHub job. This means the next queued item can't start until VoxHub finishes — even though the user already cancelled and the result will be discarded.

## Root cause

`cancel()` sends a VoxHub cancel signal and sets `status=cancelled` in the DB, but the polling loop inside `_process_next` only checks VoxHub's job status. It doesn't check whether the DB row was cancelled, so it keeps looping until VoxHub responds.

## Fix

`on_progress` (called every poll cycle) now checks the DB status at the start of each tick. If the status is `cancelled`, it raises an exception that propagates through the VoxHub polling loop, exits `_processing_lock`, and lets the next queued job start immediately.

The exception is caught by the existing error handler in `_process_next`, which checks `status == cancelled` before overwriting it with `failed` — so the final DB state is correct.

## Test scenario

1. Submit a long recording
2. While it's in the diarization stage, click Cancel
3. Verify the next queued item starts within one poll cycle (~3s) rather than waiting for diarization to complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)