### PR TITLE
feat: show live elapsed time for processing items in queue panel

### DIFF
--- a/frontend/src/components/QueuePanel.tsx
+++ b/frontend/src/components/QueuePanel.tsx
@@ -25,6 +25,24 @@ function formatTimeAgo(timestamp: number): string {
   return `${hours}h ago`;
 }
 
+function ElapsedTime({ startedAt }: { startedAt: string | null | undefined }) {
+  const [, tick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => tick(n => n + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+  if (!startedAt) return null;
+  const seconds = Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000);
+  if (seconds < 5) return null;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return (
+    <span className="text-[11px] text-gray-400 dark:text-gray-500">
+      {m > 0 ? `${m}m ${s}s` : `${s}s`}
+    </span>
+  );
+}
+
 function getStageLabel(stage: string | null | undefined): string {
   switch (stage) {
     case 'uploading':
@@ -203,6 +221,7 @@ function QueuePanel() {
                           <span className="text-xs text-blue-600 dark:text-blue-400">
                             {getStageLabel(t.progress_stage)}
                           </span>
+                          <ElapsedTime startedAt={t.started_at} />
                         </>
                       )}
                     </div>


### PR DESCRIPTION
## Problem

When a long-running stage (e.g. speaker diarization) is in progress, the progress bar can sit at the same percentage for several minutes with no indication of whether the job is still running or stuck. The only signal is the stage label ("Identifying speakers..."), which gives no sense of elapsed time.

## Fix

Adds an `ElapsedTime` component that ticks every second from `started_at`. It's displayed alongside the stage label for processing items:

```
⟳ Identifying speakers (may take a while)...  4m 12s
```

The timer:
- Only appears after 5 seconds (avoids flicker on fast jobs)
- Is driven by a local `setInterval` — no backend changes required
- Is independent of progress velocity, so it stays accurate even when the backend sends infrequent updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)