### PR TITLE
fix: recover orphaned processing jobs on startup

### DIFF
--- a/backend/app/services/queue.py
+++ b/backend/app/services/queue.py
@@ -38,8 +38,37 @@ class TranscriptionQueue:
         if self._running:
             return
         self._running = True
+        await self._recover_orphaned_jobs()
         self._worker_task = asyncio.create_task(self._worker_loop())
         logger.info("Transcription queue worker started")
+
+    async def _recover_orphaned_jobs(self):
+        """Reset any processing jobs left over from a previous process.
+
+        On a clean restart there are no live workers, so any job still marked
+        processing was orphaned mid-run. Reset it to queued so the worker
+        picks it up again.
+        """
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(
+                select(Transcription).where(
+                    Transcription.status == TranscriptionStatus.processing
+                )
+            )
+            orphans = result.scalars().all()
+            if not orphans:
+                return
+            for t in orphans:
+                t.status = TranscriptionStatus.queued
+                t.started_at = None
+                t.progress = 0
+                t.progress_stage = None
+            await db.commit()
+            logger.info(
+                "Recovered %d orphaned processing job(s) → queued: %s",
+                len(orphans),
+                [str(t.id) for t in orphans],
+            )
 
     async def stop(self):
         """Stop the background worker."""


### PR DESCRIPTION
## Problem

If the backend process is restarted (pod restart, crash, redeploy) while a transcription is mid-processing, the DB row is left with `status=processing`. On the next startup, `_process_next` checks for any `processing` row and returns immediately ("already processing something"), so the worker loop never picks up any queued jobs. The queue is blocked indefinitely until someone manually resets the row in the DB.

## Fix

`_recover_orphaned_jobs()` runs once during `start()`, before the worker loop begins. It finds any rows with `status=processing` (which can't have a live worker since we just started), resets them to `queued`, and clears `started_at`/`progress`/`progress_stage` so they're picked up cleanly on the first worker tick.

## Behaviour

- On a normal startup with no orphans: no-op, no DB queries after the initial check returns empty
- On a startup after a crash/restart: orphaned jobs are reset and logged at INFO level, then processed in queue order

🤖 Generated with [Claude Code](https://claude.com/claude-code)