### PR TITLE
feat: user-created templates, admin review flow, and template_manager role

### DIFF
--- a/backend/alembic/versions/022_template_visibility.py
+++ b/backend/alembic/versions/022_template_visibility.py
@@ -1,0 +1,84 @@
+"""Add visibility + review fields to summary_templates.
+
+Adds visibility enum (private/pending_review/public), plus reviewed_by,
+reviewed_at, and review_feedback columns to support user-created templates
+and admin review flow (Sprint 6 — roadmap 4.1 + 4.2).
+
+All existing templates are backfilled to `public` because they were
+admin-created under the previous model.
+
+Revision ID: 022_template_visibility
+Revises: 021_user_group_name_unique
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "022_template_visibility"
+down_revision = "021_user_group_name_unique"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create the TemplateVisibility enum type
+    visibility_enum = sa.Enum(
+        "private", "pending_review", "public", name="templatevisibility"
+    )
+    visibility_enum.create(op.get_bind(), checkfirst=True)
+
+    # Add visibility column — existing rows default to 'public' (they were all
+    # admin-created under the previous model).
+    op.add_column(
+        "summary_templates",
+        sa.Column(
+            "visibility",
+            sa.Enum("private", "pending_review", "public", name="templatevisibility"),
+            nullable=False,
+            server_default="public",
+        ),
+    )
+
+    # Review metadata — all nullable, only populated during/after review.
+    op.add_column(
+        "summary_templates",
+        sa.Column("reviewed_by", sa.UUID(), nullable=True),
+    )
+    op.add_column(
+        "summary_templates",
+        sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "summary_templates",
+        sa.Column("review_feedback", sa.Text(), nullable=True),
+    )
+
+    op.create_foreign_key(
+        "fk_summary_templates_reviewed_by",
+        "summary_templates", "users",
+        ["reviewed_by"], ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_summary_templates_visibility",
+        "summary_templates",
+        ["visibility"],
+    )
+    op.create_index(
+        "ix_summary_templates_created_by",
+        "summary_templates",
+        ["created_by"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_summary_templates_created_by", table_name="summary_templates")
+    op.drop_index("ix_summary_templates_visibility", table_name="summary_templates")
+    op.drop_constraint(
+        "fk_summary_templates_reviewed_by", "summary_templates", type_="foreignkey"
+    )
+    op.drop_column("summary_templates", "review_feedback")
+    op.drop_column("summary_templates", "reviewed_at")
+    op.drop_column("summary_templates", "reviewed_by")
+    op.drop_column("summary_templates", "visibility")
+    sa.Enum(name="templatevisibility").drop(op.get_bind(), checkfirst=True)

--- a/backend/alembic/versions/023_notifications.py
+++ b/backend/alembic/versions/023_notifications.py
@@ -1,0 +1,58 @@
+"""Create notifications table for in-app user notifications.
+
+Lightweight notifications used by the template review flow (Sprint 6 — 4.2).
+Scoped to a single user, with a type discriminator and an optional link
+that the frontend can navigate to when the notification is clicked.
+
+Revision ID: 023_notifications
+Revises: 022_template_visibility
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "023_notifications"
+down_revision = "022_template_visibility"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("type", sa.String(length=64), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("link", sa.String(length=512), nullable=True),
+        sa.Column(
+            "is_read",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    # Composite index to efficiently fetch unread notifications per user
+    op.create_index(
+        "ix_notifications_user_read_created",
+        "notifications",
+        ["user_id", "is_read", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notifications_user_read_created", table_name="notifications")
+    op.drop_table("notifications")

--- a/backend/alembic/versions/024_template_manager_role.py
+++ b/backend/alembic/versions/024_template_manager_role.py
@@ -1,0 +1,35 @@
+"""Add template_manager value to the userrole enum.
+
+Introduces a scoped admin role that can review pending template submissions
+and manage (edit/toggle/delete) any template, including built-in ones, but
+has no other admin privileges.
+
+Postgres requires ``ALTER TYPE ... ADD VALUE`` to run outside a transaction
+block, hence ``autocommit_block``. Downgrade is intentionally a no-op:
+Postgres has no safe way to drop a single enum value once it's been used
+in any column.
+
+Revision ID: 024_template_manager_role
+Revises: 023_notifications
+"""
+
+from alembic import op
+
+revision = "024_template_manager_role"
+down_revision = "023_notifications"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'template_manager'"
+        )
+
+
+def downgrade() -> None:
+    # Dropping a value from a Postgres enum is unsafe if any row uses it.
+    # Leave the value in place on downgrade; the application simply stops
+    # recognising it because the Python enum will be rolled back.
+    pass

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -71,3 +71,20 @@ async def require_admin(
             detail="Admin access required",
         )
     return current_user
+
+
+async def require_template_manager(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Require template management privileges.
+
+    Allows both full admins and the scoped ``template_manager`` role.
+    Used by endpoints in the templates router that moderate or manage
+    templates system-wide (approve/reject, toggle, global delete/edit).
+    """
+    if current_user.role not in (UserRole.admin, UserRole.template_manager):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Template management access required",
+        )
+    return current_user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from app.routers import shares as shares_router
 from app.routers import voice_profiles as voice_profiles_router
 from app.routers import oidc as oidc_router
 from app.routers import export as export_router
+from app.routers import notifications as notifications_router
 from app.models.template import SummaryTemplate
 from app.default_templates import DEFAULT_TEMPLATES
 import logging
@@ -60,6 +61,7 @@ app.include_router(voice_profiles_router.router, prefix="/api")
 app.include_router(oidc_router.public_router, prefix="/api")
 app.include_router(oidc_router.admin_router, prefix="/api")
 app.include_router(export_router.router, prefix="/api")
+app.include_router(notifications_router.router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,9 +9,10 @@ from app.models.user_group import UserGroup, user_group_members
 from app.models.resource_share import ResourceShare
 from app.models.oidc_provider import OIDCProvider
 from app.models.user_identity import UserIdentity
+from app.models.notification import Notification
 
 __all__ = [
     "User", "Collection", "Transcription", "SummaryTemplate", "Summary",
     "AppSetting", "ChatConversation", "UserGroup", "user_group_members", "ResourceShare",
-    "OIDCProvider", "UserIdentity",
+    "OIDCProvider", "UserIdentity", "Notification",
 ]

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,0 +1,34 @@
+from sqlalchemy import String, DateTime, ForeignKey, Text, Boolean
+from sqlalchemy.orm import mapped_column, Mapped
+import uuid
+from datetime import datetime
+from app.database import Base
+
+
+class Notification(Base):
+    """Lightweight in-app notification for a single user.
+
+    `type` is a free-form discriminator (e.g. "template_approved",
+    "template_rejected") used by the frontend to pick icons/labels.
+    `link` is an optional in-app route the UI can navigate to on click.
+    """
+
+    __tablename__ = "notifications"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    type: Mapped[str] = mapped_column(String(64), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=True)
+    link: Mapped[str] = mapped_column(String(512), nullable=True)
+    is_read: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+
+    def __repr__(self) -> str:
+        return f"<Notification(id={self.id}, user_id={self.user_id}, type={self.type!r}, read={self.is_read})>"

--- a/backend/app/models/template.py
+++ b/backend/app/models/template.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import mapped_column, Mapped, relationship
 import uuid
 from datetime import datetime
 from enum import Enum
+from typing import Optional
 from app.database import Base
 
 
@@ -11,6 +12,20 @@ class TemplateTargetType(str, Enum):
     record = "record"
     whisper = "whisper"
     both = "both"
+
+
+class TemplateVisibility(str, Enum):
+    """Lifecycle/visibility state for a template.
+
+    - `private`: visible only to the creator (default for user-created templates).
+    - `pending_review`: submitted by the creator for admin approval. Visible to
+      creator + admins only — not to other regular users.
+    - `public`: approved, visible to all users. Once public, the template is
+      admin-owned; the original creator can no longer edit it.
+    """
+    private = "private"
+    pending_review = "pending_review"
+    public = "public"
 
 
 class SummaryTemplate(Base):
@@ -22,11 +37,28 @@ class SummaryTemplate(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=True)
     prompt_template: Mapped[str] = mapped_column(Text, nullable=False)
-    created_by: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id"), nullable=False, index=True
+    )
     category: Mapped[str] = mapped_column(String(100), nullable=True)
     target_type: Mapped[TemplateTargetType] = mapped_column(
         SQLEnum(TemplateTargetType), default=TemplateTargetType.both, nullable=False, server_default="both"
     )
+    # Visibility defaults to `public` in Python so the existing admin-create flow
+    # keeps producing public templates without explicit changes. The user-create
+    # endpoint explicitly overrides this to `private`.
+    visibility: Mapped[TemplateVisibility] = mapped_column(
+        SQLEnum(TemplateVisibility),
+        default=TemplateVisibility.public,
+        nullable=False,
+        server_default="public",
+        index=True,
+    )
+    reviewed_by: Mapped[Optional[uuid.UUID]] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    reviewed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    review_feedback: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     is_default: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
@@ -36,6 +68,7 @@ class SummaryTemplate(Base):
 
     # Relationships
     creator: Mapped["User"] = relationship(foreign_keys=[created_by])
+    reviewer: Mapped[Optional["User"]] = relationship(foreign_keys=[reviewed_by])
 
     def __repr__(self) -> str:
-        return f"<SummaryTemplate(id={self.id}, name={self.name!r})>"
+        return f"<SummaryTemplate(id={self.id}, name={self.name!r}, visibility={self.visibility.value if hasattr(self.visibility, 'value') else self.visibility})>"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -8,8 +8,16 @@ from app.database import Base
 
 
 class UserRole(str, Enum):
-    """User role enumeration."""
+    """User role enumeration.
+
+    - ``admin``: full system administration.
+    - ``template_manager``: scoped admin for template management. Can review
+      pending submissions and manage (edit/toggle/delete) any template,
+      including built-in ones, but has no other admin privileges.
+    - ``user``: regular authenticated user.
+    """
     admin = "admin"
+    template_manager = "template_manager"
     user = "user"
 
 

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,0 +1,124 @@
+"""In-app notifications router.
+
+Scoped per-user: a user can only see and mutate their own notifications.
+"""
+
+from typing import List
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select, func, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.models.notification import Notification
+from app.models.user import User
+from app.schemas.notification import (
+    NotificationCountResponse,
+    NotificationResponse,
+)
+
+
+router = APIRouter(prefix="/notifications", tags=["notifications"])
+
+
+@router.get("", response_model=List[NotificationResponse])
+async def list_my_notifications(
+    unread_only: bool = Query(False),
+    limit: int = Query(50, ge=1, le=200),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the current user's notifications, newest first."""
+    query = (
+        select(Notification)
+        .where(Notification.user_id == current_user.id)
+        .order_by(Notification.created_at.desc())
+        .limit(limit)
+    )
+    if unread_only:
+        query = query.where(Notification.is_read == False)  # noqa: E712
+    result = await db.execute(query)
+    return result.scalars().all()
+
+
+@router.get("/count", response_model=NotificationCountResponse)
+async def count_my_notifications(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return total + unread counts for the current user (for a badge)."""
+    total_res = await db.execute(
+        select(func.count()).select_from(Notification).where(
+            Notification.user_id == current_user.id
+        )
+    )
+    unread_res = await db.execute(
+        select(func.count()).select_from(Notification).where(
+            Notification.user_id == current_user.id,
+            Notification.is_read == False,  # noqa: E712
+        )
+    )
+    return NotificationCountResponse(
+        total=total_res.scalar_one(),
+        unread=unread_res.scalar_one(),
+    )
+
+
+@router.post("/{notification_id}/read", response_model=NotificationResponse)
+async def mark_read(
+    notification_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Mark a single notification as read."""
+    result = await db.execute(
+        select(Notification).where(Notification.id == notification_id)
+    )
+    notification = result.scalars().first()
+    if not notification or notification.user_id != current_user.id:
+        # Don't leak existence of other users' notifications
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Notification not found"
+        )
+    notification.is_read = True
+    await db.commit()
+    await db.refresh(notification)
+    return notification
+
+
+@router.post("/read-all", status_code=status.HTTP_204_NO_CONTENT)
+async def mark_all_read(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Mark every notification for the current user as read."""
+    await db.execute(
+        update(Notification)
+        .where(
+            Notification.user_id == current_user.id,
+            Notification.is_read == False,  # noqa: E712
+        )
+        .values(is_read=True)
+    )
+    await db.commit()
+
+
+@router.delete("/{notification_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_notification(
+    notification_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a single notification owned by the current user."""
+    result = await db.execute(
+        select(Notification).where(Notification.id == notification_id)
+    )
+    notification = result.scalars().first()
+    if not notification or notification.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Notification not found"
+        )
+    await db.delete(notification)
+    await db.commit()

--- a/backend/app/routers/templates.py
+++ b/backend/app/routers/templates.py
@@ -1,35 +1,119 @@
+from datetime import datetime
 from typing import Optional
+import uuid
+
 from fastapi import APIRouter, HTTPException, status, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, or_
+
 from app.database import get_db
 from app.schemas.template import (
     SummaryTemplateCreate,
     SummaryTemplateResponse,
     SummaryTemplateUpdate,
+    TemplateRejectRequest,
 )
-from app.models.template import SummaryTemplate
-from app.models.user import User
-from app.dependencies import get_current_user, require_admin
-import uuid
+from app.models.template import SummaryTemplate, TemplateVisibility
+from app.models.user import User, UserRole
+from app.dependencies import (
+    get_current_user,
+    require_template_manager,
+)
+from app.services import notifications as notif_service
+
 
 router = APIRouter(prefix="/templates", tags=["templates"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_template_manager(user: User) -> bool:
+    """True when the user has template-management privileges (admin or scoped role)."""
+    return user.role in (UserRole.admin, UserRole.template_manager)
+
+
+def _can_edit(user: User, template: SummaryTemplate) -> bool:
+    """Permission rule for editing a template.
+
+    - Admin or template_manager: can edit anything (including built-in templates).
+    - Creator: can edit while the template is `private` or `pending_review`.
+      Once the template is `public` it becomes admin-owned (per product
+      decision for Sprint 6), so non-privileged creators can no longer edit.
+    - Default templates (seeded `is_default=True`) are manager-only.
+    """
+    if _is_template_manager(user):
+        return True
+    if template.is_default:
+        return False
+    if template.created_by != user.id:
+        return False
+    return template.visibility in (
+        TemplateVisibility.private,
+        TemplateVisibility.pending_review,
+    )
+
+
+def _can_view(user: User, template: SummaryTemplate) -> bool:
+    """Permission rule for viewing a single template by ID."""
+    if _is_template_manager(user):
+        return True
+    if template.visibility == TemplateVisibility.public:
+        return True
+    # private + pending_review are visible to the creator only
+    return template.created_by == user.id
+
+
+# ---------------------------------------------------------------------------
+# List & get
+# ---------------------------------------------------------------------------
 
 
 @router.get("", response_model=list[SummaryTemplateResponse])
 async def list_templates(
     skip: int = Query(0, ge=0),
-    limit: int = Query(50, ge=1, le=100),
+    limit: int = Query(100, ge=1, le=200),
     include_inactive: bool = Query(False),
     target_type: Optional[str] = Query(None, regex="^(record|whisper)$"),
+    visibility: Optional[str] = Query(
+        None, regex="^(private|pending_review|public)$"
+    ),
+    mine: bool = Query(False, description="Return only the current user's templates"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """List summary templates. Optionally filter by target_type (record/whisper).
-    When target_type is given, returns templates matching that type OR 'both'."""
+    """List summary templates.
+
+    Visibility rules:
+    - Non-admins see: all `public` templates + their own private/pending ones.
+    - Admins see: everything, unless filtered.
+
+    Filters:
+    - `target_type`: matches that type OR `both`.
+    - `visibility`: exact match (admin-only filter except when combined with `mine`).
+    - `mine`: scope to templates where `created_by == current_user`.
+    - `include_inactive`: admins only — non-admins never see inactive templates.
+    """
     query = select(SummaryTemplate)
-    if not include_inactive or current_user.role.value != "admin":
-        query = query.where(SummaryTemplate.is_active == True)
+
+    # Visibility scoping — privileged users (admin/template_manager) see
+    # everything; regular users only see public templates OR their own.
+    if not _is_template_manager(current_user):
+        query = query.where(
+            or_(
+                SummaryTemplate.visibility == TemplateVisibility.public,
+                SummaryTemplate.created_by == current_user.id,
+            )
+        )
+
+    # Active filter — regular users never see inactive templates; privileged
+    # users only see them when opting in with ``include_inactive``.
+    if not _is_template_manager(current_user) or not include_inactive:
+        query = query.where(SummaryTemplate.is_active == True)  # noqa: E712
+
+    # Target-type filter (whisper/record → match that OR "both")
     if target_type:
         query = query.where(
             or_(
@@ -37,53 +121,32 @@ async def list_templates(
                 SummaryTemplate.target_type == "both",
             )
         )
+
+    # Visibility-specific filter. For non-admins, `pending_review`/`private`
+    # is still only their own, because of the scoping clause above.
+    if visibility:
+        query = query.where(SummaryTemplate.visibility == visibility)
+
+    # "Mine" filter — useful for the user's template management UI.
+    if mine:
+        query = query.where(SummaryTemplate.created_by == current_user.id)
+
     result = await db.execute(query.offset(skip).limit(limit))
-    templates = result.scalars().all()
-    return templates
+    return result.scalars().all()
 
 
-@router.patch("/{template_id}/toggle", response_model=SummaryTemplateResponse)
-async def toggle_template(
-    template_id: uuid.UUID,
-    current_user: User = Depends(require_admin),
+@router.get("/pending-review", response_model=list[SummaryTemplateResponse])
+async def list_pending_review(
+    current_user: User = Depends(require_template_manager),
     db: AsyncSession = Depends(get_db),
 ):
-    """Toggle a template's active state (admin only)."""
+    """Review queue: templates awaiting approval (admin or template_manager)."""
     result = await db.execute(
-        select(SummaryTemplate).where(SummaryTemplate.id == template_id)
+        select(SummaryTemplate)
+        .where(SummaryTemplate.visibility == TemplateVisibility.pending_review)
+        .order_by(SummaryTemplate.updated_at.asc())
     )
-    template = result.scalars().first()
-    if not template:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Template not found",
-        )
-    template.is_active = not template.is_active
-    await db.commit()
-    await db.refresh(template)
-    return template
-
-
-@router.post("", response_model=SummaryTemplateResponse, status_code=status.HTTP_201_CREATED)
-async def create_template(
-    template_create: SummaryTemplateCreate,
-    current_user: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
-):
-    """Create a new summary template (admin only)."""
-    template = SummaryTemplate(
-        name=template_create.name,
-        description=template_create.description,
-        prompt_template=template_create.prompt_template,
-        category=template_create.category,
-        target_type=template_create.target_type,
-        created_by=current_user.id,
-        is_active=template_create.is_active,
-    )
-    db.add(template)
-    await db.commit()
-    await db.refresh(template)
-    return template
+    return result.scalars().all()
 
 
 @router.get("/{template_id}", response_model=SummaryTemplateResponse)
@@ -100,10 +163,51 @@ async def get_template(
 
     if not template:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Template not found",
+            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
         )
 
+    if not _can_view(current_user, template):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
+        )
+
+    return template
+
+
+# ---------------------------------------------------------------------------
+# Create / update / delete
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model=SummaryTemplateResponse, status_code=status.HTTP_201_CREATED)
+async def create_template(
+    template_create: SummaryTemplateCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new summary template.
+
+    - Admins and template_managers create directly as `public` (current
+      behaviour preserved for admins; extended to the scoped role).
+    - Regular users create as `private`; they can then submit for review.
+    """
+    initial_visibility = (
+        TemplateVisibility.public if _is_template_manager(current_user) else TemplateVisibility.private
+    )
+
+    template = SummaryTemplate(
+        name=template_create.name,
+        description=template_create.description,
+        prompt_template=template_create.prompt_template,
+        category=template_create.category,
+        target_type=template_create.target_type,
+        created_by=current_user.id,
+        is_active=template_create.is_active,
+        visibility=initial_visibility,
+    )
+    db.add(template)
+    await db.commit()
+    await db.refresh(template)
     return template
 
 
@@ -111,10 +215,15 @@ async def get_template(
 async def update_template(
     template_id: uuid.UUID,
     template_update: SummaryTemplateUpdate,
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update a summary template (admin only)."""
+    """Update a summary template.
+
+    Admins can edit anything. Non-admin creators can edit their own template
+    while it is `private` or `pending_review`; once it becomes `public`, only
+    admins can edit.
+    """
     result = await db.execute(
         select(SummaryTemplate).where(SummaryTemplate.id == template_id)
     )
@@ -122,8 +231,13 @@ async def update_template(
 
     if not template:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Template not found",
+            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
+        )
+
+    if not _can_edit(current_user, template):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to edit this template",
         )
 
     if template_update.name is not None:
@@ -136,9 +250,36 @@ async def update_template(
         template.category = template_update.category
     if template_update.target_type is not None:
         template.target_type = template_update.target_type
+    # Only privileged users get to flip is_active — it's a moderation control.
     if template_update.is_active is not None:
+        if not _is_template_manager(current_user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only admins or template managers can toggle template active state",
+            )
         template.is_active = template_update.is_active
 
+    await db.commit()
+    await db.refresh(template)
+    return template
+
+
+@router.patch("/{template_id}/toggle", response_model=SummaryTemplateResponse)
+async def toggle_template(
+    template_id: uuid.UUID,
+    current_user: User = Depends(require_template_manager),
+    db: AsyncSession = Depends(get_db),
+):
+    """Toggle a template's active state (admin or template_manager)."""
+    result = await db.execute(
+        select(SummaryTemplate).where(SummaryTemplate.id == template_id)
+    )
+    template = result.scalars().first()
+    if not template:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
+        )
+    template.is_active = not template.is_active
     await db.commit()
     await db.refresh(template)
     return template
@@ -147,10 +288,17 @@ async def update_template(
 @router.delete("/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_template(
     template_id: uuid.UUID,
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Delete/deactivate a summary template (admin only)."""
+    """Delete a template.
+
+    - Built-in (`is_default=True`) templates are never deleted; privileged
+      users can only deactivate them.
+    - Privileged users (admin or template_manager) can delete any
+      non-default template.
+    - Regular creators can delete their own private or pending templates.
+    """
     result = await db.execute(
         select(SummaryTemplate).where(SummaryTemplate.id == template_id)
     )
@@ -158,15 +306,158 @@ async def delete_template(
 
     if not template:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Template not found",
+            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
         )
 
     if template.is_default:
-        # Default (built-in) templates can only be deactivated, not deleted
+        if not _is_template_manager(current_user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Built-in templates can only be managed by admins or template managers",
+            )
         template.is_active = False
         await db.commit()
-    else:
-        # User-created templates can be permanently deleted
-        await db.delete(template)
-        await db.commit()
+        return
+
+    if not _can_edit(current_user, template):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to delete this template",
+        )
+
+    await db.delete(template)
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Review flow
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{template_id}/submit", response_model=SummaryTemplateResponse)
+async def submit_for_review(
+    template_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Creator submits their private template for admin review."""
+    result = await db.execute(
+        select(SummaryTemplate).where(SummaryTemplate.id == template_id)
+    )
+    template = result.scalars().first()
+    if not template:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
+        )
+
+    if template.created_by != current_user.id and not _is_template_manager(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the creator can submit this template",
+        )
+    if template.visibility != TemplateVisibility.private:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Template cannot be submitted from state '{template.visibility.value if hasattr(template.visibility, 'value') else template.visibility}'",
+        )
+
+    template.visibility = TemplateVisibility.pending_review
+    # Clear any stale feedback from a previous rejection.
+    template.review_feedback = None
+    template.reviewed_by = None
+    template.reviewed_at = None
+    await db.commit()
+    await db.refresh(template)
+    return template
+
+
+@router.post("/{template_id}/approve", response_model=SummaryTemplateResponse)
+async def approve_template(
+    template_id: uuid.UUID,
+    current_user: User = Depends(require_template_manager),
+    db: AsyncSession = Depends(get_db),
+):
+    """Reviewer approves a pending template → visibility becomes `public`.
+
+    Per Sprint 6 decision, a public template is admin-owned: the original
+    creator can no longer edit it. The `created_by` field is preserved for
+    attribution, but the edit permission check in `_can_edit` denies the
+    creator once the template is public.
+    """
+    result = await db.execute(
+        select(SummaryTemplate).where(SummaryTemplate.id == template_id)
+    )
+    template = result.scalars().first()
+    if not template:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
+        )
+    if template.visibility != TemplateVisibility.pending_review:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only templates in 'pending_review' can be approved",
+        )
+
+    template.visibility = TemplateVisibility.public
+    template.reviewed_by = current_user.id
+    template.reviewed_at = datetime.utcnow()
+    template.review_feedback = None
+
+    # Fire in-app notification to the creator; flush alongside the template
+    # change so the whole thing is one commit.
+    await notif_service.notify_template_approved(
+        db,
+        user_id=template.created_by,
+        template_name=template.name,
+        template_id=template.id,
+        commit=False,
+    )
+
+    await db.commit()
+    await db.refresh(template)
+    return template
+
+
+@router.post("/{template_id}/reject", response_model=SummaryTemplateResponse)
+async def reject_template(
+    template_id: uuid.UUID,
+    payload: TemplateRejectRequest,
+    current_user: User = Depends(require_template_manager),
+    db: AsyncSession = Depends(get_db),
+):
+    """Reviewer rejects a pending template → visibility returns to `private`.
+
+    Optional reviewer `feedback` is stored on the template and surfaced in
+    the creator's notification so they know what to fix.
+    """
+    result = await db.execute(
+        select(SummaryTemplate).where(SummaryTemplate.id == template_id)
+    )
+    template = result.scalars().first()
+    if not template:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
+        )
+    if template.visibility != TemplateVisibility.pending_review:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only templates in 'pending_review' can be rejected",
+        )
+
+    template.visibility = TemplateVisibility.private
+    template.reviewed_by = current_user.id
+    template.reviewed_at = datetime.utcnow()
+    template.review_feedback = payload.feedback
+
+    await notif_service.notify_template_rejected(
+        db,
+        user_id=template.created_by,
+        template_name=template.name,
+        template_id=template.id,
+        feedback=payload.feedback,
+        commit=False,
+    )
+
+    await db.commit()
+    await db.refresh(template)
+    return template

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+from typing import Optional
+import uuid
+from datetime import datetime
+
+
+class NotificationResponse(BaseModel):
+    id: uuid.UUID
+    type: str
+    title: str
+    body: Optional[str] = None
+    link: Optional[str] = None
+    is_read: bool
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class NotificationCountResponse(BaseModel):
+    total: int
+    unread: int

--- a/backend/app/schemas/template.py
+++ b/backend/app/schemas/template.py
@@ -33,6 +33,10 @@ class SummaryTemplateResponse(BaseModel):
     category: Optional[str] = None
     target_type: str = "both"
     created_by: uuid.UUID
+    visibility: str = "public"  # "private" | "pending_review" | "public"
+    reviewed_by: Optional[uuid.UUID] = None
+    reviewed_at: Optional[datetime] = None
+    review_feedback: Optional[str] = None
     is_active: bool
     is_default: bool = False
     created_at: datetime
@@ -40,3 +44,8 @@ class SummaryTemplateResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class TemplateRejectRequest(BaseModel):
+    """Admin rejection with optional feedback shown to the template creator."""
+    feedback: Optional[str] = None

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1,0 +1,87 @@
+"""Tiny helper for creating in-app notifications.
+
+Kept intentionally small — templated notifications for Sprint 6 plus a
+generic `create` for future callers. No email integration here; that can
+be layered in later by composing this with the existing email service.
+"""
+
+from typing import Optional
+import uuid
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification import Notification
+
+
+async def create_notification(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    type: str,
+    title: str,
+    body: Optional[str] = None,
+    link: Optional[str] = None,
+    commit: bool = True,
+) -> Notification:
+    """Create a notification for a single user.
+
+    The caller controls whether we commit immediately. When composed inside
+    another transaction (e.g. template approval), pass ``commit=False`` so the
+    notification is flushed alongside the caller's changes.
+    """
+    notification = Notification(
+        user_id=user_id,
+        type=type,
+        title=title,
+        body=body,
+        link=link,
+    )
+    db.add(notification)
+    if commit:
+        await db.commit()
+        await db.refresh(notification)
+    else:
+        await db.flush()
+    return notification
+
+
+async def notify_template_approved(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    template_name: str,
+    template_id: uuid.UUID,
+    commit: bool = False,
+) -> Notification:
+    return await create_notification(
+        db,
+        user_id=user_id,
+        type="template_approved",
+        title="Template approved",
+        body=f"Your template \u201c{template_name}\u201d has been approved and is now available to everyone.",
+        link="/admin?tab=templates",
+        commit=commit,
+    )
+
+
+async def notify_template_rejected(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    template_name: str,
+    template_id: uuid.UUID,
+    feedback: Optional[str],
+    commit: bool = False,
+) -> Notification:
+    body = f"Your template \u201c{template_name}\u201d was not approved."
+    if feedback:
+        body += f" Reviewer feedback: {feedback}"
+    return await create_notification(
+        db,
+        user_id=user_id,
+        type="template_rejected",
+        title="Template not approved",
+        body=body,
+        # User lands on their templates; frontend can highlight the rejected one.
+        link=f"/templates?focus={template_id}",
+        commit=commit,
+    )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { CollectionDetail } from '@/pages/CollectionDetail';
 import { Chat } from '@/pages/Chat';
 import { Settings } from '@/pages/Settings';
 import { MyGroups } from '@/pages/MyGroups';
+import { MyTemplates } from '@/pages/MyTemplates';
 import { AdminPanel } from '@/pages/admin/AdminPanel';
 
 // Components
@@ -141,7 +142,7 @@ function App() {
       <Route
         path="/admin"
         element={
-          <ProtectedRoute adminOnly>
+          <ProtectedRoute adminOnly allowTemplateManager>
             <AdminPanel />
           </ProtectedRoute>
         }
@@ -155,6 +156,14 @@ function App() {
         element={
           <ProtectedRoute>
             <MyGroups />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/templates"
+        element={
+          <ProtectedRoute>
+            <MyTemplates />
           </ProtectedRoute>
         }
       />

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -1,0 +1,28 @@
+import { apiClient } from './client';
+import { AppNotification, NotificationCount } from '@/types';
+
+export const notificationsApi = {
+  async list(options: { unreadOnly?: boolean; limit?: number } = {}): Promise<AppNotification[]> {
+    const params = new URLSearchParams();
+    if (options.unreadOnly) params.set('unread_only', 'true');
+    if (options.limit) params.set('limit', String(options.limit));
+    const qs = params.toString();
+    return apiClient.get<AppNotification[]>(`/notifications${qs ? `?${qs}` : ''}`);
+  },
+
+  async count(): Promise<NotificationCount> {
+    return apiClient.get<NotificationCount>('/notifications/count');
+  },
+
+  async markRead(id: string): Promise<AppNotification> {
+    return apiClient.post<AppNotification>(`/notifications/${id}/read`, {});
+  },
+
+  async markAllRead(): Promise<void> {
+    return apiClient.post<void>('/notifications/read-all', {});
+  },
+
+  async delete(id: string): Promise<void> {
+    return apiClient.delete<void>(`/notifications/${id}`);
+  },
+};

--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -1,12 +1,12 @@
 import { apiClient } from './client';
-import { SummaryTemplate } from '@/types';
+import { SummaryTemplate, TemplateTargetType, TemplateVisibility } from '@/types';
 
 interface CreateTemplateData {
   name: string;
   description: string;
   prompt_template: string;
   category?: string;
-  target_type?: string;
+  target_type?: TemplateTargetType;
 }
 
 interface UpdateTemplateData {
@@ -14,17 +14,30 @@ interface UpdateTemplateData {
   description?: string;
   prompt_template?: string;
   category?: string;
-  target_type?: string;
+  target_type?: TemplateTargetType;
   is_active?: boolean;
 }
 
+interface ListTemplatesOptions {
+  includeInactive?: boolean;
+  targetType?: 'record' | 'whisper';
+  visibility?: TemplateVisibility;
+  mine?: boolean;
+}
+
 export const templatesApi = {
-  async getTemplates(includeInactive = false, targetType?: 'record' | 'whisper'): Promise<SummaryTemplate[]> {
+  async getTemplates(options: ListTemplatesOptions = {}): Promise<SummaryTemplate[]> {
     const params = new URLSearchParams();
-    if (includeInactive) params.set('include_inactive', 'true');
-    if (targetType) params.set('target_type', targetType);
+    if (options.includeInactive) params.set('include_inactive', 'true');
+    if (options.targetType) params.set('target_type', options.targetType);
+    if (options.visibility) params.set('visibility', options.visibility);
+    if (options.mine) params.set('mine', 'true');
     const qs = params.toString();
     return apiClient.get<SummaryTemplate[]>(`/templates${qs ? `?${qs}` : ''}`);
+  },
+
+  async getPendingReview(): Promise<SummaryTemplate[]> {
+    return apiClient.get<SummaryTemplate[]>('/templates/pending-review');
   },
 
   async createTemplate(data: CreateTemplateData): Promise<SummaryTemplate> {
@@ -41,5 +54,17 @@ export const templatesApi = {
 
   async deleteTemplate(id: string): Promise<void> {
     return apiClient.delete<void>(`/templates/${id}`);
+  },
+
+  async submitForReview(id: string): Promise<SummaryTemplate> {
+    return apiClient.post<SummaryTemplate>(`/templates/${id}/submit`, {});
+  },
+
+  async approveTemplate(id: string): Promise<SummaryTemplate> {
+    return apiClient.post<SummaryTemplate>(`/templates/${id}/approve`, {});
+  },
+
+  async rejectTemplate(id: string, feedback?: string): Promise<SummaryTemplate> {
+    return apiClient.post<SummaryTemplate>(`/templates/${id}/reject`, { feedback: feedback ?? null });
   },
 };

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '@/store/useAuthStore';
 import { useAppStore } from '@/store/useAppStore';
 import { useLayoutStore } from '@/store/useLayoutStore';
 import { QueueIndicator } from '@/components/QueuePanel';
+import { NotificationsBell } from '@/components/NotificationsBell';
 
 interface HeaderProps {
   title?: string;
@@ -70,6 +71,9 @@ export function Header({ title }: HeaderProps) {
 
         {/* Queue indicator */}
         <QueueIndicator />
+
+        {/* Notifications bell */}
+        <NotificationsBell />
 
         {/* Theme toggle */}
         <button

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   ChevronLeft,
   ChevronRight,
   X,
+  BookTemplate,
 } from 'lucide-react';
 import { useEffect } from 'react';
 import { useAuthStore } from '@/store/useAuthStore';
@@ -58,12 +59,19 @@ export function Sidebar() {
     { path: '/transcriptions', label: 'Transcriptions', icon: FileText },
     { path: '/collections', label: 'Collections', icon: FolderOpen },
     { path: '/groups', label: 'My Groups', icon: Users },
+    { path: '/templates', label: 'My Templates', icon: BookTemplate },
     { path: '/chat', label: 'Chat', icon: MessageSquare },
   ];
 
-  const adminItems = user?.role === 'admin' ? [
-    { path: '/admin', label: 'Administration', icon: Shield },
-  ] : [];
+  const adminItems = (() => {
+    if (user?.role === 'admin') {
+      return [{ path: '/admin', label: 'Administration', icon: Shield }];
+    }
+    if (user?.role === 'template_manager') {
+      return [{ path: '/admin', label: 'Template management', icon: Shield }];
+    }
+    return [];
+  })();
 
   const sidebarContent = (
     <>

--- a/frontend/src/components/NotificationsBell.tsx
+++ b/frontend/src/components/NotificationsBell.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Bell, Check, Trash2 } from 'lucide-react';
+import { notificationsApi } from '@/api/notifications';
+import { AppNotification } from '@/types';
+
+const POLL_MS = 30_000;
+
+export function NotificationsBell() {
+  const navigate = useNavigate();
+  const [items, setItems] = useState<AppNotification[]>([]);
+  const [unread, setUnread] = useState(0);
+  const [open, setOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const refreshCount = async () => {
+    try {
+      const c = await notificationsApi.count();
+      setUnread(c.unread);
+    } catch {
+      // Silent — notifications are non-critical.
+    }
+  };
+
+  const loadList = async () => {
+    setIsLoading(true);
+    try {
+      const list = await notificationsApi.list({ limit: 20 });
+      setItems(list);
+      setUnread(list.filter((n) => !n.is_read).length);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Poll for unread count in the background
+  useEffect(() => {
+    refreshCount();
+    const interval = setInterval(refreshCount, POLL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Load full list when opening the panel
+  useEffect(() => {
+    if (open) loadList();
+  }, [open]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const markRead = async (n: AppNotification) => {
+    if (n.is_read) return;
+    try {
+      const updated = await notificationsApi.markRead(n.id);
+      setItems((prev) => prev.map((x) => (x.id === n.id ? updated : x)));
+      setUnread((u) => Math.max(0, u - 1));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const onClickItem = async (n: AppNotification) => {
+    await markRead(n);
+    setOpen(false);
+    if (n.link) navigate(n.link);
+  };
+
+  const markAllRead = async () => {
+    try {
+      await notificationsApi.markAllRead();
+      setItems((prev) => prev.map((n) => ({ ...n, is_read: true })));
+      setUnread(0);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const deleteOne = async (n: AppNotification) => {
+    try {
+      await notificationsApi.delete(n.id);
+      setItems((prev) => prev.filter((x) => x.id !== n.id));
+      if (!n.is_read) setUnread((u) => Math.max(0, u - 1));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="relative" ref={panelRef}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className={`relative p-2 sm:p-2.5 rounded-xl transition-all duration-200 ${
+          open
+            ? 'bg-gray-100 dark:bg-gray-700/60 text-gray-900 dark:text-white'
+            : 'hover:bg-gray-100 dark:hover:bg-gray-700/60 text-gray-600 dark:text-gray-400'
+        }`}
+        aria-label="Notifications"
+      >
+        <Bell className="w-5 h-5" />
+        {unread > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-white text-[10px] font-semibold flex items-center justify-center">
+            {unread > 99 ? '99+' : unread}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-[22rem] max-w-[calc(100vw-2rem)] bg-white dark:bg-gray-800 rounded-xl shadow-xl border border-gray-200/60 dark:border-gray-700/40 z-50 overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-700/60">
+            <p className="text-sm font-semibold text-gray-900 dark:text-white">Notifications</p>
+            {items.some((n) => !n.is_read) && (
+              <button
+                onClick={markAllRead}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-[22rem] overflow-y-auto">
+            {isLoading ? (
+              <div className="p-6 text-center text-sm text-gray-500 dark:text-gray-400">Loading…</div>
+            ) : items.length === 0 ? (
+              <div className="p-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                You're all caught up.
+              </div>
+            ) : (
+              <ul className="divide-y divide-gray-100 dark:divide-gray-700/60">
+                {items.map((n) => (
+                  <li
+                    key={n.id}
+                    className={`px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors ${
+                      !n.is_read ? 'bg-blue-50/40 dark:bg-blue-900/10' : ''
+                    }`}
+                  >
+                    <div className="flex items-start gap-3">
+                      <button
+                        onClick={() => onClickItem(n)}
+                        className="flex-1 min-w-0 text-left"
+                      >
+                        <div className="flex items-center gap-2">
+                          {!n.is_read && (
+                            <span className="w-2 h-2 rounded-full bg-blue-500 shrink-0" />
+                          )}
+                          <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                            {n.title}
+                          </p>
+                        </div>
+                        {n.body && (
+                          <p className="text-xs text-gray-600 dark:text-gray-400 mt-0.5 line-clamp-2">
+                            {n.body}
+                          </p>
+                        )}
+                        <p className="text-[11px] text-gray-400 dark:text-gray-500 mt-1">
+                          {new Date(n.created_at).toLocaleString()}
+                        </p>
+                      </button>
+                      <div className="flex flex-col gap-1 shrink-0">
+                        {!n.is_read && (
+                          <button
+                            onClick={() => markRead(n)}
+                            title="Mark read"
+                            className="p-1 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 rounded"
+                          >
+                            <Check className="w-4 h-4" />
+                          </button>
+                        )}
+                        <button
+                          onClick={() => deleteOne(n)}
+                          title="Delete"
+                          className="p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400 rounded"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -4,9 +4,16 @@ import { useAuthStore } from '@/store/useAuthStore';
 interface ProtectedRouteProps {
   children: React.ReactNode;
   adminOnly?: boolean;
+  // Allow scoped roles (template_manager) that share the admin panel path
+  // with strictly-admin features. The panel itself hides tabs based on role.
+  allowTemplateManager?: boolean;
 }
 
-export function ProtectedRoute({ children, adminOnly = false }: ProtectedRouteProps) {
+export function ProtectedRoute({
+  children,
+  adminOnly = false,
+  allowTemplateManager = false,
+}: ProtectedRouteProps) {
   const { isAuthenticated, user, isLoading, forcePasswordReset } = useAuthStore();
   const location = useLocation();
 
@@ -27,8 +34,13 @@ export function ProtectedRoute({ children, adminOnly = false }: ProtectedRoutePr
     return <Navigate to="/change-password" replace />;
   }
 
-  if (adminOnly && user?.role !== 'admin') {
-    return <Navigate to="/dashboard" replace />;
+  if (adminOnly) {
+    const role = user?.role;
+    const allowed =
+      role === 'admin' || (allowTemplateManager && role === 'template_manager');
+    if (!allowed) {
+      return <Navigate to="/dashboard" replace />;
+    }
   }
 
   return <>{children}</>;

--- a/frontend/src/components/TranscribeModal.tsx
+++ b/frontend/src/components/TranscribeModal.tsx
@@ -83,7 +83,7 @@ export function TranscribeModal({
 
   const loadTemplates = async () => {
     try {
-      const t = await templatesApi.getTemplates(false, recordingType);
+      const t = await templatesApi.getTemplates({ targetType: recordingType });
       setTemplates(t);
       if (t.length > 0) {
         setSelectedTemplate(t[0].id);

--- a/frontend/src/pages/MyTemplates.tsx
+++ b/frontend/src/pages/MyTemplates.tsx
@@ -1,0 +1,436 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Layout } from '@/components/Layout';
+import { templatesApi } from '@/api/templates';
+import { SummaryTemplate, TemplateTargetType } from '@/types';
+import {
+  Plus,
+  Save,
+  X,
+  Edit,
+  Trash2,
+  Send,
+  Lock,
+  Clock,
+  Globe,
+  AlertTriangle,
+} from 'lucide-react';
+
+const CATEGORY_SUGGESTIONS = [
+  'General',
+  'HR',
+  'Client & Sales',
+  'Project Management',
+  'Leadership',
+  'Security',
+  'Education',
+  'Media',
+  'Healthcare',
+  'UX & Research',
+  'Personal',
+];
+
+interface FormState {
+  name: string;
+  description: string;
+  prompt_template: string;
+  category: string;
+  target_type: TemplateTargetType;
+}
+
+const EMPTY_FORM: FormState = {
+  name: '',
+  description: '',
+  prompt_template: '',
+  category: '',
+  target_type: 'both',
+};
+
+export function MyTemplates() {
+  const [templates, setTemplates] = useState<SummaryTemplate[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [error, setError] = useState<string | null>(null);
+  const [searchParams] = useSearchParams();
+  const focusId = searchParams.get('focus');
+
+  useEffect(() => {
+    loadMine();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const loadMine = async () => {
+    setIsLoading(true);
+    try {
+      const t = await templatesApi.getTemplates({ mine: true, includeInactive: true });
+      setTemplates(t);
+    } catch (err) {
+      console.error('Failed to load templates:', err);
+      setError('Failed to load templates');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const focused = useMemo(
+    () => (focusId ? templates.find((t) => t.id === focusId) : null),
+    [focusId, templates],
+  );
+
+  const startCreate = () => {
+    setForm(EMPTY_FORM);
+    setEditingId(null);
+    setIsCreating(true);
+  };
+
+  const startEdit = (t: SummaryTemplate) => {
+    setForm({
+      name: t.name,
+      description: t.description || '',
+      prompt_template: t.prompt_template,
+      category: t.category || '',
+      target_type: t.target_type || 'both',
+    });
+    setEditingId(t.id);
+    setIsCreating(false);
+  };
+
+  const cancel = () => {
+    setForm(EMPTY_FORM);
+    setEditingId(null);
+    setIsCreating(false);
+  };
+
+  const save = async () => {
+    if (!form.name.trim() || !form.prompt_template.trim()) {
+      setError('Name and prompt are required');
+      return;
+    }
+    setError(null);
+    try {
+      if (editingId) {
+        const updated = await templatesApi.updateTemplate(editingId, form);
+        setTemplates((prev) => prev.map((t) => (t.id === editingId ? updated : t)));
+      } else {
+        const created = await templatesApi.createTemplate(form);
+        setTemplates((prev) => [...prev, created]);
+      }
+      cancel();
+    } catch (err) {
+      console.error(err);
+      setError('Save failed. Please try again.');
+    }
+  };
+
+  const submit = async (t: SummaryTemplate) => {
+    try {
+      const updated = await templatesApi.submitForReview(t.id);
+      setTemplates((prev) => prev.map((x) => (x.id === t.id ? updated : x)));
+    } catch (err) {
+      console.error(err);
+      setError('Could not submit for review.');
+    }
+  };
+
+  const remove = async (t: SummaryTemplate) => {
+    if (!window.confirm(`Delete template "${t.name}"? This cannot be undone.`)) return;
+    try {
+      await templatesApi.deleteTemplate(t.id);
+      setTemplates((prev) => prev.filter((x) => x.id !== t.id));
+    } catch (err) {
+      console.error(err);
+      setError('Delete failed.');
+    }
+  };
+
+  return (
+    <Layout title="My Templates">
+      <div className="space-y-6">
+        <div className="flex items-start justify-between gap-4">
+          <p className="text-sm text-gray-600 dark:text-gray-400 max-w-2xl">
+            Create your own summary templates. Templates start as{' '}
+            <span className="font-medium">private</span> — only you can use them. Submit a template for
+            review to share it with everyone. Once approved, a template becomes public and is managed
+            by admins.
+          </p>
+          {!isCreating && !editingId && (
+            <button
+              onClick={startCreate}
+              className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors shrink-0"
+            >
+              <Plus className="w-4 h-4" />
+              New template
+            </button>
+          )}
+        </div>
+
+        {error && (
+          <div className="flex items-center gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-sm">
+            <AlertTriangle className="w-4 h-4 shrink-0" />
+            {error}
+          </div>
+        )}
+
+        {(isCreating || editingId) && (
+          <TemplateForm
+            form={form}
+            setForm={setForm}
+            onSave={save}
+            onCancel={cancel}
+            title={editingId ? 'Edit template' : 'Create template'}
+          />
+        )}
+
+        {isLoading ? (
+          <div className="p-12 text-center text-gray-500 dark:text-gray-400">Loading…</div>
+        ) : templates.length === 0 ? (
+          <div className="p-12 text-center text-gray-500 dark:text-gray-400 border border-dashed border-gray-300 dark:border-gray-700 rounded-lg">
+            You don't have any templates yet. Click "New template" to create one.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {templates.map((t) => (
+              <TemplateRow
+                key={t.id}
+                template={t}
+                highlight={focused?.id === t.id}
+                onEdit={startEdit}
+                onDelete={remove}
+                onSubmit={submit}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}
+
+function TemplateForm({
+  form,
+  setForm,
+  onSave,
+  onCancel,
+  title,
+}: {
+  form: FormState;
+  setForm: (f: FormState) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  title: string;
+}) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
+      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">{title}</h2>
+      <div className="space-y-4">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              className="w-full px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Template name"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Category</label>
+            <input
+              type="text"
+              value={form.category}
+              onChange={(e) => setForm({ ...form, category: e.target.value })}
+              className="w-full px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="e.g. General, Personal"
+              list="category-suggestions-user"
+            />
+            <datalist id="category-suggestions-user">
+              {CATEGORY_SUGGESTIONS.map((c) => (
+                <option key={c} value={c} />
+              ))}
+            </datalist>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Target</label>
+            <select
+              value={form.target_type}
+              onChange={(e) => setForm({ ...form, target_type: e.target.value as TemplateTargetType })}
+              className="w-full px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="both">Both (Record + Whisper)</option>
+              <option value="record">Record only</option>
+              <option value="whisper">Whisper only</option>
+            </select>
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Description</label>
+          <input
+            type="text"
+            value={form.description}
+            onChange={(e) => setForm({ ...form, description: e.target.value })}
+            className="w-full px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="Brief description of what this template does"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Prompt</label>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+            Use {'{{transcript}}'} for transcription text, {'{{meeting_date}}'} for the date extracted
+            from the device filename.
+          </p>
+          <textarea
+            value={form.prompt_template}
+            onChange={(e) => setForm({ ...form, prompt_template: e.target.value })}
+            rows={6}
+            className="w-full px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg text-sm font-mono resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="Enter prompt template…"
+          />
+        </div>
+        <div className="flex gap-3">
+          <button
+            onClick={onSave}
+            className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium text-sm"
+          >
+            <Save className="w-4 h-4" />
+            Save
+          </button>
+          <button
+            onClick={onCancel}
+            className="flex items-center gap-2 px-4 py-2 bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-white rounded-lg font-medium text-sm"
+          >
+            <X className="w-4 h-4" />
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function VisibilityBadge({ template }: { template: SummaryTemplate }) {
+  if (template.visibility === 'private') {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+        <Lock className="w-3 h-3" />
+        Private
+      </span>
+    );
+  }
+  if (template.visibility === 'pending_review') {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200">
+        <Clock className="w-3 h-3" />
+        Pending review
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200">
+      <Globe className="w-3 h-3" />
+      Public
+    </span>
+  );
+}
+
+function TemplateRow({
+  template,
+  highlight,
+  onEdit,
+  onDelete,
+  onSubmit,
+}: {
+  template: SummaryTemplate;
+  highlight: boolean;
+  onEdit: (t: SummaryTemplate) => void;
+  onDelete: (t: SummaryTemplate) => void;
+  onSubmit: (t: SummaryTemplate) => void;
+}) {
+  const canEdit = template.visibility === 'private' || template.visibility === 'pending_review';
+  const canSubmit = template.visibility === 'private';
+
+  return (
+    <div
+      className={`p-5 rounded-lg border transition-colors ${
+        highlight
+          ? 'border-amber-400 dark:border-amber-500 bg-amber-50/60 dark:bg-amber-900/10'
+          : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            {template.category && (
+              <span className="px-2 py-0.5 text-xs font-medium rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
+                {template.category}
+              </span>
+            )}
+            <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+              {template.name}
+            </h3>
+            <VisibilityBadge template={template} />
+            {template.target_type && template.target_type !== 'both' && (
+              <span
+                className={`px-2 py-0.5 text-xs font-medium rounded ${
+                  template.target_type === 'whisper'
+                    ? 'bg-violet-100 dark:bg-violet-900 text-violet-700 dark:text-violet-300'
+                    : 'bg-sky-100 dark:bg-sky-900 text-sky-700 dark:text-sky-300'
+                }`}
+              >
+                {template.target_type === 'whisper' ? 'Whisper' : 'Record'}
+              </span>
+            )}
+          </div>
+          {template.description && (
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">{template.description}</p>
+          )}
+          {template.review_feedback && template.visibility === 'private' && (
+            <div className="mt-3 p-3 rounded bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/50 text-sm text-red-700 dark:text-red-300">
+              <p className="font-medium mb-1">Reviewer feedback</p>
+              <p className="whitespace-pre-wrap">{template.review_feedback}</p>
+            </div>
+          )}
+          <p className="text-xs text-gray-500 dark:text-gray-500 mt-3 bg-gray-50 dark:bg-gray-900/40 p-2 rounded font-mono line-clamp-3">
+            {template.prompt_template}
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2 mt-4">
+        {canEdit && (
+          <button
+            onClick={() => onEdit(template)}
+            className="flex items-center gap-1 px-3 py-1 text-sm bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded hover:bg-blue-200 dark:hover:bg-blue-800 transition-colors"
+          >
+            <Edit className="w-4 h-4" />
+            Edit
+          </button>
+        )}
+        {canSubmit && (
+          <button
+            onClick={() => onSubmit(template)}
+            className="flex items-center gap-1 px-3 py-1 text-sm bg-amber-100 dark:bg-amber-900/60 text-amber-800 dark:text-amber-200 rounded hover:bg-amber-200 dark:hover:bg-amber-800/70 transition-colors"
+          >
+            <Send className="w-4 h-4" />
+            Submit for review
+          </button>
+        )}
+        {canEdit && (
+          <button
+            onClick={() => onDelete(template)}
+            className="flex items-center gap-1 px-3 py-1 text-sm bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300 rounded hover:bg-red-200 dark:hover:bg-red-800 transition-colors"
+          >
+            <Trash2 className="w-4 h-4" />
+            Delete
+          </button>
+        )}
+        {template.visibility === 'public' && (
+          <span className="text-xs text-gray-500 dark:text-gray-500 italic self-center">
+            Approved and public — managed by admins.
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/TranscriptionDetail.tsx
+++ b/frontend/src/pages/TranscriptionDetail.tsx
@@ -203,7 +203,7 @@ export function TranscriptionDetail() {
       setSummaries(s);
 
       const recType = t.recording_type === 'whisper' ? 'whisper' : 'record';
-      const temps = await templatesApi.getTemplates(false, showAllTemplates ? undefined : recType);
+      const temps = await templatesApi.getTemplates({ targetType: showAllTemplates ? undefined : recType });
       setTemplates(temps);
 
       const colls = await collectionsApi.list();
@@ -266,7 +266,7 @@ export function TranscriptionDetail() {
   useEffect(() => {
     if (!transcription) return;
     const recType = transcription.recording_type === 'whisper' ? 'whisper' : 'record';
-    templatesApi.getTemplates(false, showAllTemplates ? undefined : recType).then((temps) => {
+    templatesApi.getTemplates({ targetType: showAllTemplates ? undefined : recType }).then((temps) => {
       setTemplates(temps);
       if (temps.length > 0 && !temps.find((t) => t.id === selectedTemplate)) {
         setSelectedTemplate(temps[0].id);

--- a/frontend/src/pages/admin/AdminPanel.tsx
+++ b/frontend/src/pages/admin/AdminPanel.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Layout } from '@/components/Layout';
+import { useAuthStore } from '@/store/useAuthStore';
 import {
   FileText,
   Shield,
@@ -10,9 +11,11 @@ import {
   KeyRound,
   Mail,
   SlidersHorizontal,
+  ClipboardCheck,
 } from 'lucide-react';
 
 import { Templates } from './Templates';
+import { TemplateReview } from './TemplateReview';
 import { Users } from './Users';
 import { Groups } from './Groups';
 import { RegistrationSettingsPage } from './RegistrationSettings';
@@ -21,12 +24,22 @@ import { FeatureSettings } from './FeatureSettings';
 import { OIDCSettings } from './OIDCSettings';
 import { EmailSettings } from './EmailSettings';
 
-type AdminTab = 'users' | 'groups' | 'templates' | 'registration' | 'sso' | 'email' | 'features' | 'api';
+type AdminTab =
+  | 'users'
+  | 'groups'
+  | 'templates'
+  | 'template-review'
+  | 'registration'
+  | 'sso'
+  | 'email'
+  | 'features'
+  | 'api';
 
 const tabs: { key: AdminTab; label: string; icon: typeof Shield }[] = [
   { key: 'users', label: 'Users', icon: Shield },
   { key: 'groups', label: 'Groups', icon: UsersIcon },
   { key: 'templates', label: 'Templates', icon: FileText },
+  { key: 'template-review', label: 'Template review', icon: ClipboardCheck },
   { key: 'registration', label: 'Registration', icon: UserPlus },
   { key: 'sso', label: 'SSO / OIDC', icon: KeyRound },
   { key: 'email', label: 'Email', icon: Mail },
@@ -34,11 +47,26 @@ const tabs: { key: AdminTab; label: string; icon: typeof Shield }[] = [
   { key: 'api', label: 'API Settings', icon: Plug },
 ];
 
+// Tabs visible to a scoped ``template_manager``. A template_manager uses
+// the same AdminPanel UI but only sees template-related tabs.
+const TEMPLATE_MANAGER_TABS: AdminTab[] = ['templates', 'template-review'];
+
 export function AdminPanel() {
+  const user = useAuthStore((s) => s.user);
+  const isAdmin = user?.role === 'admin';
+  const visibleTabs = useMemo(
+    () =>
+      isAdmin
+        ? tabs
+        : tabs.filter((t) => TEMPLATE_MANAGER_TABS.includes(t.key)),
+    [isAdmin],
+  );
+  const defaultTab: AdminTab = isAdmin ? 'users' : 'template-review';
+
   const [searchParams, setSearchParams] = useSearchParams();
-  const initialTab = (searchParams.get('tab') as AdminTab) || 'users';
+  const initialTab = (searchParams.get('tab') as AdminTab) || defaultTab;
   const [activeTab, setActiveTab] = useState<AdminTab>(
-    tabs.some((t) => t.key === initialTab) ? initialTab : 'users'
+    visibleTabs.some((t) => t.key === initialTab) ? initialTab : defaultTab
   );
 
   const handleTabChange = (tab: AdminTab) => {
@@ -54,6 +82,8 @@ export function AdminPanel() {
         return <Groups embedded />;
       case 'templates':
         return <Templates embedded />;
+      case 'template-review':
+        return <TemplateReview embedded />;
       case 'registration':
         return <RegistrationSettingsPage embedded />;
       case 'sso':
@@ -70,12 +100,12 @@ export function AdminPanel() {
   };
 
   return (
-    <Layout title="Administration">
+    <Layout title={isAdmin ? 'Administration' : 'Template management'}>
       <div className="space-y-6">
         {/* Tab navigation */}
         <div className="border-b border-gray-200 dark:border-gray-700">
           <nav className="flex gap-1 -mb-px overflow-x-auto" aria-label="Admin tabs">
-            {tabs.map(({ key, label, icon: Icon }) => {
+            {visibleTabs.map(({ key, label, icon: Icon }) => {
               const isActive = activeTab === key;
               return (
                 <button

--- a/frontend/src/pages/admin/TemplateReview.tsx
+++ b/frontend/src/pages/admin/TemplateReview.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useState } from 'react';
+import { Layout } from '@/components/Layout';
+import { templatesApi } from '@/api/templates';
+import { SummaryTemplate } from '@/types';
+import { Check, X, AlertTriangle, RefreshCw, Inbox } from 'lucide-react';
+
+/**
+ * Admin review queue for user-submitted templates.
+ *
+ * Lists templates in `pending_review`, letting an admin:
+ *  - Approve (→ public, creator gets a notification).
+ *  - Reject with optional feedback (→ back to private with feedback stored
+ *    on the template + surfaced in the creator's notification).
+ *
+ * "Edit before approving" is intentionally not implemented as a separate
+ * mode: admins can open the template in the main Templates tab (which has
+ * full admin edit), then come back and approve. Keeps this view focused.
+ */
+export function TemplateReview({ embedded }: { embedded?: boolean }) {
+  const [pending, setPending] = useState<SummaryTemplate[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [rejectingId, setRejectingId] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState('');
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const items = await templatesApi.getPendingReview();
+      setPending(items);
+    } catch (err) {
+      console.error(err);
+      setError('Failed to load pending templates.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const approve = async (t: SummaryTemplate) => {
+    setBusyId(t.id);
+    try {
+      await templatesApi.approveTemplate(t.id);
+      setPending((prev) => prev.filter((x) => x.id !== t.id));
+    } catch (err) {
+      console.error(err);
+      setError(`Could not approve "${t.name}".`);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const openReject = (t: SummaryTemplate) => {
+    setRejectingId(t.id);
+    setFeedback('');
+  };
+
+  const confirmReject = async () => {
+    if (!rejectingId) return;
+    setBusyId(rejectingId);
+    try {
+      await templatesApi.rejectTemplate(rejectingId, feedback.trim() || undefined);
+      setPending((prev) => prev.filter((x) => x.id !== rejectingId));
+      setRejectingId(null);
+      setFeedback('');
+    } catch (err) {
+      console.error(err);
+      setError('Could not reject template.');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const cancelReject = () => {
+    setRejectingId(null);
+    setFeedback('');
+  };
+
+  const content = (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Template review queue
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Templates submitted by users waiting for approval.
+          </p>
+        </div>
+        <button
+          onClick={load}
+          className="flex items-center gap-2 px-3 py-2 text-sm bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-lg transition-colors"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-sm">
+          <AlertTriangle className="w-4 h-4 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="p-12 text-center text-gray-500 dark:text-gray-400">Loading…</div>
+      ) : pending.length === 0 ? (
+        <div className="p-12 text-center border border-dashed border-gray-300 dark:border-gray-700 rounded-lg text-gray-500 dark:text-gray-400">
+          <Inbox className="w-8 h-8 mx-auto mb-2 opacity-50" />
+          No templates waiting for review.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {pending.map((t) => (
+            <div
+              key={t.id}
+              className="p-5 rounded-lg border border-amber-200 dark:border-amber-800/60 bg-amber-50/40 dark:bg-amber-900/10"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    {t.category && (
+                      <span className="px-2 py-0.5 text-xs font-medium rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
+                        {t.category}
+                      </span>
+                    )}
+                    <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+                      {t.name}
+                    </h3>
+                    {t.target_type && t.target_type !== 'both' && (
+                      <span
+                        className={`px-2 py-0.5 text-xs font-medium rounded ${
+                          t.target_type === 'whisper'
+                            ? 'bg-violet-100 dark:bg-violet-900 text-violet-700 dark:text-violet-300'
+                            : 'bg-sky-100 dark:bg-sky-900 text-sky-700 dark:text-sky-300'
+                        }`}
+                      >
+                        {t.target_type === 'whisper' ? 'Whisper' : 'Record'}
+                      </span>
+                    )}
+                  </div>
+                  {t.description && (
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                      {t.description}
+                    </p>
+                  )}
+                  <pre className="text-xs text-gray-600 dark:text-gray-300 mt-3 bg-white dark:bg-gray-900/40 p-3 rounded border border-gray-200 dark:border-gray-700 whitespace-pre-wrap font-mono">
+                    {t.prompt_template}
+                  </pre>
+                  <p className="text-xs text-gray-500 dark:text-gray-500 mt-2">
+                    Submitted {new Date(t.updated_at).toLocaleString()}
+                  </p>
+                </div>
+              </div>
+
+              {rejectingId === t.id ? (
+                <div className="mt-4 space-y-2">
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Rejection feedback <span className="text-gray-400">(optional)</span>
+                  </label>
+                  <textarea
+                    value={feedback}
+                    onChange={(e) => setFeedback(e.target.value)}
+                    rows={3}
+                    className="w-full px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+                    placeholder="What should the creator change before resubmitting?"
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      onClick={confirmReject}
+                      disabled={busyId === t.id}
+                      className="flex items-center gap-1 px-3 py-1.5 text-sm bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white rounded transition-colors"
+                    >
+                      <X className="w-4 h-4" />
+                      Confirm reject
+                    </button>
+                    <button
+                      onClick={cancelReject}
+                      className="px-3 py-1.5 text-sm bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-white rounded"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex gap-2 mt-4">
+                  <button
+                    onClick={() => approve(t)}
+                    disabled={busyId === t.id}
+                    className="flex items-center gap-1 px-3 py-1.5 text-sm bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white rounded transition-colors"
+                  >
+                    <Check className="w-4 h-4" />
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => openReject(t)}
+                    disabled={busyId === t.id}
+                    className="flex items-center gap-1 px-3 py-1.5 text-sm bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-800 rounded transition-colors"
+                  >
+                    <X className="w-4 h-4" />
+                    Reject
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  if (embedded) return content;
+  return <Layout title="Template review">{content}</Layout>;
+}

--- a/frontend/src/pages/admin/Templates.tsx
+++ b/frontend/src/pages/admin/Templates.tsx
@@ -61,7 +61,7 @@ export function Templates({ embedded }: { embedded?: boolean }) {
   const loadTemplates = async () => {
     setIsLoading(true);
     try {
-      const t = await templatesApi.getTemplates(true); // include inactive for admin
+      const t = await templatesApi.getTemplates({ includeInactive: true }); // include inactive for admin
       setTemplates(t);
     } catch (error) {
       console.error('Failed to load templates:', error);

--- a/frontend/src/pages/admin/Users.tsx
+++ b/frontend/src/pages/admin/Users.tsx
@@ -273,11 +273,17 @@ export function Users({ embedded }: { embedded?: boolean }) {
                           className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium ${
                             user.role === 'admin'
                               ? 'bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300'
-                              : 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300'
+                              : user.role === 'template_manager'
+                                ? 'bg-amber-100 dark:bg-amber-900/60 text-amber-800 dark:text-amber-200'
+                                : 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300'
                           }`}
                         >
-                          {user.role === 'admin' ? <Shield className="w-3 h-3" /> : <UserIcon className="w-3 h-3" />}
-                          {user.role}
+                          {user.role === 'admin' || user.role === 'template_manager' ? (
+                            <Shield className="w-3 h-3" />
+                          ) : (
+                            <UserIcon className="w-3 h-3" />
+                          )}
+                          {user.role === 'template_manager' ? 'template manager' : user.role}
                         </span>
                       </td>
                       <td className="px-6 py-4 text-sm">{statusBadge(user)}</td>
@@ -507,12 +513,15 @@ function CreateUserModal({
               className="w-full px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500/50"
             >
               <option value="user">User</option>
+              <option value="template_manager">Template manager</option>
               <option value="admin">Admin</option>
             </select>
           </div>
 
           <p className="text-xs text-gray-500 dark:text-gray-400">
             Admin-created accounts bypass registration restrictions and are immediately active.
+            Template managers can review user-submitted templates and manage any template
+            (including built-in), but have no other admin privileges.
           </p>
 
           <div className="flex justify-end gap-3 pt-2">
@@ -651,6 +660,7 @@ function EditUserModal({
                 className="w-full px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500/50"
               >
                 <option value="user">User</option>
+                <option value="template_manager">Template manager</option>
                 <option value="admin">Admin</option>
               </select>
             </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,4 +1,4 @@
-export type UserRole = 'admin' | 'user';
+export type UserRole = 'admin' | 'template_manager' | 'user';
 export type UserStatus = 'active' | 'pending' | 'rejected';
 export type RegistrationSource = 'self_registered' | 'admin_created' | 'oidc';
 
@@ -143,6 +143,7 @@ export interface SharedWithMeItem {
 }
 
 export type TemplateTargetType = 'record' | 'whisper' | 'both';
+export type TemplateVisibility = 'private' | 'pending_review' | 'public';
 
 export interface SummaryTemplate {
   id: string;
@@ -151,9 +152,30 @@ export interface SummaryTemplate {
   prompt_template: string;
   category: string | null;
   target_type: TemplateTargetType;
+  created_by: string;
+  visibility: TemplateVisibility;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  review_feedback: string | null;
   is_active: boolean;
   is_default: boolean;
   created_at: string;
+  updated_at: string;
+}
+
+export interface AppNotification {
+  id: string;
+  type: string;
+  title: string;
+  body: string | null;
+  link: string | null;
+  is_read: boolean;
+  created_at: string;
+}
+
+export interface NotificationCount {
+  total: number;
+  unread: number;
 }
 
 export interface Summary {


### PR DESCRIPTION
Sprint 6 (ROADMAP 4.1 + 4.2):

- Templates now have a visibility lifecycle: private -> pending_review -> public. Users create private templates and submit them for review; admins approve (template becomes admin-owned/public) or reject (returned to private with optional feedback).
- New in-app notifications system: users are notified when their submitted template is approved or rejected. Header bell with unread count, dropdown list, mark-read on click, and mark-all / per-item delete.
- New 'template_manager' role: non-admin users who can be assigned by admins to manage templates. They reach /admin with a scoped tab set (Templates + Template review only) and see 'Template management' as the panel title.
- Migrations: 022 template visibility+review fields, 023 notifications table, 024 adds template_manager to the userrole enum.
- Frontend: new MyTemplates page (creator view with submit-for-review), admin/TemplateReview queue, NotificationsBell, role-aware Sidebar / AdminPanel / ProtectedRoute, template_manager option in user admin.
