### PR TITLE
Phase6 search pin batch notifications

### DIFF
--- a/backend/alembic/versions/025_phase6_search_pin_prefs.py
+++ b/backend/alembic/versions/025_phase6_search_pin_prefs.py
@@ -1,0 +1,90 @@
+"""Phase 6 — full-text search, pinning, and notification prefs.
+
+This migration bundles three small schema changes for Phase 6 features:
+
+* ``transcriptions.is_pinned`` (6.2 — Favorites / pinning)
+* GIN expression index on ``to_tsvector(title || ' ' || text)`` for the
+  transcriptions table (6.1 — Full-text search). Using an expression index
+  instead of a stored tsvector column keeps the model simple and avoids
+  trigger maintenance; ``simple`` is used as the dictionary to behave the
+  same way regardless of the user's locale.
+* ``users.notify_on_completion`` and ``users.notify_email_on_completion``
+  (6.5 — Notifications on transcription complete).
+
+Revision ID: 025_phase6_search_pin_prefs
+Revises: 024_template_manager_role
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "025_phase6_search_pin_prefs"
+down_revision = "024_template_manager_role"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- 6.2: pinning ---------------------------------------------------
+    op.add_column(
+        "transcriptions",
+        sa.Column(
+            "is_pinned",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    # Partial index — most rows are unpinned, so this stays tiny and is
+    # used to short-circuit the "show pinned first" ordering.
+    op.create_index(
+        "ix_transcriptions_is_pinned",
+        "transcriptions",
+        ["is_pinned"],
+        postgresql_where=sa.text("is_pinned"),
+    )
+
+    # --- 6.1: full-text search index -----------------------------------
+    # GIN expression index on title + text. Uses ``simple`` so search
+    # works across English/French/etc. without needing per-row language
+    # detection. ``coalesce`` guards against NULLs.
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_transcriptions_fts
+        ON transcriptions
+        USING GIN (
+            to_tsvector(
+                'simple',
+                coalesce(title, '') || ' ' || coalesce(text, '')
+            )
+        )
+        """
+    )
+
+    # --- 6.5: per-user notification preferences ------------------------
+    op.add_column(
+        "users",
+        sa.Column(
+            "notify_on_completion",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "notify_email_on_completion",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "notify_email_on_completion")
+    op.drop_column("users", "notify_on_completion")
+    op.execute("DROP INDEX IF EXISTS ix_transcriptions_fts")
+    op.drop_index("ix_transcriptions_is_pinned", table_name="transcriptions")
+    op.drop_column("transcriptions", "is_pinned")

--- a/backend/alembic/versions/026_per_user_pins.py
+++ b/backend/alembic/versions/026_per_user_pins.py
@@ -1,0 +1,101 @@
+"""Phase 6 follow-up — per-user transcription pins.
+
+The first cut of pinning (migration 025) stored ``is_pinned`` on the
+``transcriptions`` row, which meant the pin was visible to every user
+that the transcription was shared with. That's the wrong model — pinning
+is a personal bookmark.
+
+This migration:
+
+1. creates a ``transcription_pins`` join table (user_id, transcription_id)
+2. backfills existing pins: for every row where ``is_pinned`` was true,
+   the owner of the transcription gets a pin row, preserving their UX
+3. drops the now-unused ``is_pinned`` column and its partial index
+
+Revision ID: 026_per_user_pins
+Revises: 025_phase6_search_pin_prefs
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "026_per_user_pins"
+down_revision = "025_phase6_search_pin_prefs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "transcription_pins",
+        sa.Column(
+            "user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "transcription_id",
+            sa.UUID(),
+            sa.ForeignKey("transcriptions.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index(
+        "ix_transcription_pins_transcription_id",
+        "transcription_pins",
+        ["transcription_id"],
+    )
+
+    # Backfill: every currently-pinned transcription becomes a pin for
+    # its owner. Anyone the transcription was shared with loses the pin,
+    # which matches the new "personal bookmark" semantics.
+    op.execute(
+        """
+        INSERT INTO transcription_pins (user_id, transcription_id)
+        SELECT user_id, id FROM transcriptions WHERE is_pinned = true
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+    op.execute("DROP INDEX IF EXISTS ix_transcriptions_is_pinned")
+    op.drop_column("transcriptions", "is_pinned")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "transcriptions",
+        sa.Column(
+            "is_pinned",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.create_index(
+        "ix_transcriptions_is_pinned",
+        "transcriptions",
+        ["is_pinned"],
+        postgresql_where=sa.text("is_pinned"),
+    )
+    # Best-effort restoration of the old flag: mark any transcription
+    # with at least one pin as pinned. The previous owner-only semantics
+    # mean the result isn't perfect, but it's better than losing pins.
+    op.execute(
+        """
+        UPDATE transcriptions SET is_pinned = true
+        WHERE id IN (SELECT DISTINCT transcription_id FROM transcription_pins)
+        """
+    )
+
+    op.drop_index(
+        "ix_transcription_pins_transcription_id",
+        table_name="transcription_pins",
+    )
+    op.drop_table("transcription_pins")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -85,4 +85,15 @@ class Settings(BaseSettings):
         if val == "true":
             return True
         # Treat as a CA bundle file path
-        return setting_value.st
+        return setting_value.strip()
+
+    @property
+    def llm_ssl_verify(self) -> Union[bool, str, ssl.SSLContext]:
+        return self.get_ssl_verify(self.llm_verify_ssl)
+
+    @property
+    def voxhub_ssl_verify(self) -> Union[bool, str, ssl.SSLContext]:
+        return self.get_ssl_verify(self.voxhub_verify_ssl)
+
+
+settings = Settings()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
     # Speaker matching threshold (cosine distance, 0.0 = identical, 1.0 = unrelated)
     speaker_match_threshold: float = 0.5
 
+    # Public base URL for the frontend (used in notification emails). When
+    # empty, completion emails still send but with a relative link — set
+    # this in production to e.g. https://openhinotes.example.com so the
+    # "Open transcription" CTA in emails goes to the right place.
+    app_base_url: str = ""
+
     class Config:
         env_file = ".env"
         case_sensitive = False
@@ -79,15 +85,4 @@ class Settings(BaseSettings):
         if val == "true":
             return True
         # Treat as a CA bundle file path
-        return setting_value.strip()
-
-    @property
-    def llm_ssl_verify(self) -> Union[bool, str, ssl.SSLContext]:
-        return self.get_ssl_verify(self.llm_verify_ssl)
-
-    @property
-    def voxhub_ssl_verify(self) -> Union[bool, str, ssl.SSLContext]:
-        return self.get_ssl_verify(self.voxhub_verify_ssl)
-
-
-settings = Settings()
+        return setting_value.st

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from app.routers import voice_profiles as voice_profiles_router
 from app.routers import oidc as oidc_router
 from app.routers import export as export_router
 from app.routers import notifications as notifications_router
+from app.routers import search as search_router
 from app.models.template import SummaryTemplate
 from app.default_templates import DEFAULT_TEMPLATES
 import logging
@@ -62,6 +63,7 @@ app.include_router(oidc_router.public_router, prefix="/api")
 app.include_router(oidc_router.admin_router, prefix="/api")
 app.include_router(export_router.router, prefix="/api")
 app.include_router(notifications_router.router, prefix="/api")
+app.include_router(search_router.router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/app/models/transcription.py
+++ b/backend/app/models/transcription.py
@@ -61,7 +61,7 @@ class Transcription(Base):
     auto_summarize_template_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("summary_templates.id", ondelete="SET NULL"), nullable=True
     )
-    # Phase 6.2 — Pinned items float to the top of lists.
+    # Phase 6.2 - Pinned items float to the top of lists.
     is_pinned: Mapped[bool] = mapped_column(
         Boolean, default=False, nullable=False, server_default="false"
     )
@@ -71,4 +71,7 @@ class Transcription(Base):
     )
 
     # Relationships
-    user
+    user: Mapped["User"] = relationship(foreign_keys=[user_id])
+
+    def __repr__(self) -> str:
+        return f"<Transcription(id={self.id}, user_id={self.user_id}, status={self.status})>"

--- a/backend/app/models/transcription.py
+++ b/backend/app/models/transcription.py
@@ -61,10 +61,6 @@ class Transcription(Base):
     auto_summarize_template_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("summary_templates.id", ondelete="SET NULL"), nullable=True
     )
-    # Phase 6.2 - Pinned items float to the top of lists.
-    is_pinned: Mapped[bool] = mapped_column(
-        Boolean, default=False, nullable=False, server_default="false"
-    )
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False

--- a/backend/app/models/transcription.py
+++ b/backend/app/models/transcription.py
@@ -61,13 +61,14 @@ class Transcription(Base):
     auto_summarize_template_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("summary_templates.id", ondelete="SET NULL"), nullable=True
     )
+    # Phase 6.2 — Pinned items float to the top of lists.
+    is_pinned: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
     )
 
     # Relationships
-    user: Mapped["User"] = relationship(foreign_keys=[user_id])
-
-    def __repr__(self) -> str:
-        return f"<Transcription(id={self.id}, user_id={self.user_id}, status={self.status})>"
+    user

--- a/backend/app/models/transcription_pin.py
+++ b/backend/app/models/transcription_pin.py
@@ -1,0 +1,39 @@
+"""Per-user transcription pin (Phase 6 follow-up).
+
+A user can pin any transcription they can read. Pins are personal —
+they do NOT propagate to other users who can see the same transcription.
+
+Modelled as a Core ``Table`` rather than an ORM class because there is
+no row-level data beyond the composite PK + a timestamp.
+"""
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Table
+from datetime import datetime
+
+from app.database import Base
+
+
+transcription_pins = Table(
+    "transcription_pins",
+    Base.metadata,
+    Column(
+        "user_id",
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "transcription_id",
+        ForeignKey("transcriptions.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "created_at",
+        DateTime,
+        default=datetime.utcnow,
+        nullable=False,
+    ),
+    Index(
+        "ix_transcription_pins_transcription_id",
+        "transcription_id",
+    ),
+)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -66,10 +66,21 @@ class User(Base):
         DateTime, nullable=True, default=None
     )
 
-    # Client-side recording aliases: filename → display name
+    # Client-side recording aliases: filename -> display name
     recording_aliases: Mapped[dict] = mapped_column(
         JSON, nullable=False, default=dict, server_default='{}'
     )
 
-    # Phase 6.5 — notification preferences. ``notify_on_completion``
-    # controls in-app + browser-push
+    # Phase 6.5 - notification preferences. ``notify_on_completion``
+    # controls in-app + browser-push notifications when one of the user's
+    # transcriptions completes. ``notify_email_on_completion`` adds an
+    # SMTP email (only sent when SMTP is configured).
+    notify_on_completion: Mapped[bool] = mapped_column(
+        Boolean, default=True, nullable=False, server_default="true"
+    )
+    notify_email_on_completion: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
+
+    def __repr__(self) -> str:
+        return f"<User(id={self.id}, email={self.email}, role={self.role})>"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -71,5 +71,5 @@ class User(Base):
         JSON, nullable=False, default=dict, server_default='{}'
     )
 
-    def __repr__(self) -> str:
-        return f"<User(id={self.id}, email={self.email}, role={self.role})>"
+    # Phase 6.5 — notification preferences. ``notify_on_completion``
+    # controls in-app + browser-push

--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -1,0 +1,133 @@
+"""Full-text search across the current user's accessible transcriptions.
+
+Backed by the GIN expression index created in migration 025. The query
+uses ``plainto_tsquery`` for forgiving input (handles spaces / extra
+punctuation), ``ts_rank`` for ordering, and ``ts_headline`` for a
+highlighted snippet with ``<mark>`` tags.
+
+Permission-aware: relies on :class:`PermissionService.list_accessible_ids`
+so users can only search content they're allowed to read.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select, func, literal_column, text as sa_text, and_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.models.transcription import Transcription, TranscriptionStatus
+from app.models.user import User, UserRole
+from app.models.resource_share import ResourceType
+from app.schemas.search import SearchHit, SearchResponse
+from app.services.permissions import PermissionService
+
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+
+@router.get("/transcriptions", response_model=SearchResponse)
+async def search_transcriptions(
+    q: str = Query(..., min_length=1, max_length=200, description="Search query"),
+    limit: int = Query(20, ge=1, le=100),
+    skip: int = Query(0, ge=0),
+    recording_type: Optional[str] = Query(
+        None, regex="^(record|whisper)$",
+        description="Restrict to a single recording type",
+    ),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Full-text search across title + transcript body.
+
+    Returns ranked hits with highlighted snippets. Only completed
+    transcriptions are searched — pending/queued/processing items have
+    no text yet, and failed ones are noise.
+    """
+    query_term = q.strip()
+    if not query_term:
+        return SearchResponse(items=[], total=0, query=q)
+
+    # ``simple`` dictionary matches the index — keep consistent.
+    tsquery = func.plainto_tsquery("simple", query_term)
+    tsvector = func.to_tsvector(
+        "simple",
+        func.coalesce(Transcription.title, "")
+        + literal_column("' '")
+        + func.coalesce(Transcription.text, ""),
+    )
+    rank_expr = func.ts_rank(tsvector, tsquery).label("rank")
+    headline_expr = func.ts_headline(
+        "simple",
+        func.coalesce(Transcription.text, ""),
+        tsquery,
+        # Keep snippets short; <mark> renders well in the existing UI.
+        "StartSel=<mark>, StopSel=</mark>, MaxFragments=2, "
+        "MinWords=5, MaxWords=18, FragmentDelimiter= … ",
+    ).label("snippet")
+
+    base_filters = [
+        tsvector.op("@@")(tsquery),
+        Transcription.status == TranscriptionStatus.completed,
+    ]
+    if recording_type:
+        base_filters.append(Transcription.recording_type == recording_type)
+
+    # Permission scope. Admins skip the filter entirely.
+    if current_user.role != UserRole.admin:
+        accessible_ids = await PermissionService.list_accessible_ids(
+            db, current_user, ResourceType.transcription
+        )
+        if not accessible_ids:
+            return SearchResponse(items=[], total=0, query=query_term)
+        base_filters.append(Transcription.id.in_(accessible_ids))
+
+    where_clause = and_(*base_filters)
+
+    # --- total count ---------------------------------------------------
+    total_q = select(func.count()).select_from(Transcription).where(where_clause)
+    total = (await db.execute(total_q)).scalar() or 0
+
+    # --- page of hits --------------------------------------------------
+    rows_q = (
+        select(
+            Transcription.id,
+            Transcription.title,
+            Transcription.original_filename,
+            Transcription.recording_type,
+            Transcription.status,
+            Transcription.is_pinned,
+            Transcription.created_at,
+            rank_expr,
+            headline_expr,
+        )
+        .where(where_clause)
+        # Pinned first, then rank, then newest — gives consistent ordering
+        # when multiple hits tie on rank.
+        .order_by(
+            Transcription.is_pinned.desc(),
+            rank_expr.desc(),
+            Transcription.created_at.desc(),
+        )
+        .offset(skip)
+        .limit(limit)
+    )
+    rows = (await db.execute(rows_q)).all()
+
+    items = [
+        SearchHit(
+            transcription_id=row[0],
+            title=row[1],
+            original_filename=row[2],
+            recording_type=str(row[3].value) if hasattr(row[3], "value") else str(row[3]),
+            status=str(row[4].value) if hasattr(row[4], "value") else str(row[4]),
+            is_pinned=bool(row[5]),
+            created_at=row[6],
+            rank=float(row[7] or 0.0),
+            snippet=row[8],
+        )
+        for row in rows
+    ]
+
+    return SearchResponse(items=items, total=int(total), query=query_term)

--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.dependencies import get_current_user
 from app.models.transcription import Transcription, TranscriptionStatus
+from app.models.transcription_pin import transcription_pins
 from app.models.user import User, UserRole
 from app.models.resource_share import ResourceType
 from app.schemas.search import SearchHit, SearchResponse
@@ -90,6 +91,14 @@ async def search_transcriptions(
     total = (await db.execute(total_q)).scalar() or 0
 
     # --- page of hits --------------------------------------------------
+    # Per-user pin lookup: a transcription is "pinned" for ordering /
+    # response purposes only if THIS user has pinned it.
+    user_pin_ids = (
+        select(transcription_pins.c.transcription_id)
+        .where(transcription_pins.c.user_id == current_user.id)
+    )
+    is_pinned_expr = Transcription.id.in_(user_pin_ids)
+
     rows_q = (
         select(
             Transcription.id,
@@ -97,7 +106,7 @@ async def search_transcriptions(
             Transcription.original_filename,
             Transcription.recording_type,
             Transcription.status,
-            Transcription.is_pinned,
+            is_pinned_expr.label("is_pinned"),
             Transcription.created_at,
             rank_expr,
             headline_expr,
@@ -106,7 +115,7 @@ async def search_transcriptions(
         # Pinned first, then rank, then newest — gives consistent ordering
         # when multiple hits tie on rank.
         .order_by(
-            Transcription.is_pinned.desc(),
+            is_pinned_expr.desc(),
             rank_expr.desc(),
             Transcription.created_at.desc(),
         )

--- a/backend/app/routers/transcriptions.py
+++ b/backend/app/routers/transcriptions.py
@@ -45,6 +45,7 @@ from app.models.resource_share import (
     PermissionLevel,
 )
 from app.models.user_group import UserGroup, user_group_members
+from app.models.transcription_pin import transcription_pins
 from app.models.user import User, UserRole
 from app.models.transcription import Transcription, TranscriptionStatus
 from app.models.summary import Summary
@@ -64,12 +65,20 @@ async def _enrich_with_permissions(
     user: User,
     db: AsyncSession,
 ) -> dict:
-    """Add permission_level to a transcription response."""
+    """Add ``permission_level`` and per-user ``is_pinned`` to a response."""
     level = await PermissionService.get_permission_level(
         db, user, ResourceType.transcription, transcription.id
     )
     data = TranscriptionResponse.model_validate(transcription).model_dump()
     data["permission_level"] = level
+    # Per-user pin lookup. Lightweight: PK lookup on the join table.
+    pin_res = await db.execute(
+        select(transcription_pins.c.user_id).where(
+            transcription_pins.c.user_id == user.id,
+            transcription_pins.c.transcription_id == transcription.id,
+        )
+    )
+    data["is_pinned"] = pin_res.scalars().first() is not None
     return data
 
 
@@ -320,15 +329,25 @@ async def list_transcriptions(
     """List transcriptions. Supports filter: all (mine + shared), mine, shared.
     Optional recording_type filter: record, whisper.
 
-    Pinned items always float to the top, regardless of the chosen sort
-    order (Phase 6.2).
+    Pinned items (per-user) always float to the top, regardless of the
+    chosen sort order. Phase 6.2 → per-user pins in Phase 6 follow-up.
     """
+    # LEFT JOIN to the per-user pin table so we can both order by pin and
+    # return ``is_pinned`` cheaply in a single round-trip. ``pin_marker``
+    # is non-null exactly when the current user has pinned the row.
+    pin_marker = transcription_pins.c.transcription_id.label("pin_marker")
+    pin_order = (
+        select(transcription_pins.c.transcription_id)
+        .where(transcription_pins.c.user_id == current_user.id)
+    )
     secondary = (
         Transcription.created_at.desc()
         if sort == "newest"
         else Transcription.created_at.asc()
     )
-    order = (Transcription.is_pinned.desc(), secondary)
+    # Sort by "is this row's id in the user's pinned set", then by date.
+    pinned_first = Transcription.id.in_(pin_order).desc()
+    order = (pinned_first, secondary)
 
     if current_user.role == UserRole.admin:
         # Admins see everything
@@ -395,11 +414,32 @@ async def list_transcriptions(
     result = await db.execute(query)
     transcriptions = result.scalars().all()
 
+    # Resolve per-user pins in one round-trip and stamp ``is_pinned`` on
+    # each response object before Pydantic serialization.
+    if transcriptions:
+        pinned_ids_res = await db.execute(
+            select(transcription_pins.c.transcription_id).where(
+                transcription_pins.c.user_id == current_user.id,
+                transcription_pins.c.transcription_id.in_(
+                    [t.id for t in transcriptions]
+                ),
+            )
+        )
+        pinned_ids = {row[0] for row in pinned_ids_res.all()}
+    else:
+        pinned_ids = set()
+
+    items = []
+    for t in transcriptions:
+        data = TranscriptionResponse.model_validate(t).model_dump()
+        data["is_pinned"] = t.id in pinned_ids
+        items.append(data)
+
     return {
-        "items": transcriptions,
+        "items": items,
         "total": total or 0,
         "skip": skip,
-        "limit": limit
+        "limit": limit,
     }
 
 
@@ -1076,7 +1116,11 @@ async def set_pinned(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Pin or unpin a transcription. Requires write access."""
+    """Pin or unpin a transcription for the current user.
+
+    Per-user — does NOT affect other users who can see the transcription.
+    Read access is enough.
+    """
     transcription = await TranscriptionService.get_transcription(db, transcription_id)
     if not transcription:
         raise HTTPException(
@@ -1084,17 +1128,32 @@ async def set_pinned(
         )
 
     has_access = await PermissionService.check_access(
-        db, current_user, ResourceType.transcription, transcription_id, "write"
+        db, current_user, ResourceType.transcription, transcription_id, "read"
     )
     if not has_access:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not authorized to update this transcription",
+            detail="Not authorized to view this transcription",
         )
 
-    transcription.is_pinned = pinned
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    from sqlalchemy import delete as sa_delete
+
+    if pinned:
+        # Upsert: ignore if the user already pinned it.
+        stmt = pg_insert(transcription_pins).values(
+            user_id=current_user.id,
+            transcription_id=transcription_id,
+        ).on_conflict_do_nothing()
+        await db.execute(stmt)
+    else:
+        await db.execute(
+            sa_delete(transcription_pins).where(
+                transcription_pins.c.user_id == current_user.id,
+                transcription_pins.c.transcription_id == transcription_id,
+            )
+        )
     await db.commit()
-    await db.refresh(transcription)
     return await _enrich_with_permissions(transcription, current_user, db)
 
 
@@ -1153,19 +1212,34 @@ async def batch_pin(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Pin / unpin multiple transcriptions."""
+    """Pin / unpin multiple transcriptions for the current user only."""
     if not payload.ids:
         return BatchResultResponse(affected=0, message="No ids provided")
 
-    allowed, skipped = await _filter_ids_by_permission(db, current_user, payload.ids, "write")
-    if allowed:
-        from sqlalchemy import update as sa_update
+    allowed, skipped = await _filter_ids_by_permission(
+        db, current_user, payload.ids, "read"
+    )
+    if not allowed:
+        return BatchResultResponse(affected=0, skipped=skipped)
+
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    from sqlalchemy import delete as sa_delete
+
+    if payload.pinned:
+        # Bulk upsert
+        rows = [
+            {"user_id": current_user.id, "transcription_id": tid} for tid in allowed
+        ]
+        stmt = pg_insert(transcription_pins).values(rows).on_conflict_do_nothing()
+        await db.execute(stmt)
+    else:
         await db.execute(
-            sa_update(Transcription)
-            .where(Transcription.id.in_(allowed))
-            .values(is_pinned=payload.pinned)
+            sa_delete(transcription_pins).where(
+                transcription_pins.c.user_id == current_user.id,
+                transcription_pins.c.transcription_id.in_(allowed),
+            )
         )
-        await db.commit()
+    await db.commit()
     return BatchResultResponse(affected=len(allowed), skipped=skipped)
 
 

--- a/backend/app/routers/transcriptions.py
+++ b/backend/app/routers/transcriptions.py
@@ -31,6 +31,20 @@ from app.schemas.transcription import (
     SegmentTextUpdate,
     TranscriptFindReplace,
 )
+from app.schemas.search import (
+    BatchIdsRequest,
+    BatchPinRequest,
+    BatchCollectionRequest,
+    BatchShareRequest,
+    BatchResultResponse,
+)
+from app.models.collection import Collection
+from app.models.resource_share import (
+    ResourceShare,
+    GranteeType,
+    PermissionLevel,
+)
+from app.models.user_group import UserGroup, user_group_members
 from app.models.user import User, UserRole
 from app.models.transcription import Transcription, TranscriptionStatus
 from app.models.summary import Summary
@@ -304,12 +318,21 @@ async def list_transcriptions(
     db: AsyncSession = Depends(get_db),
 ):
     """List transcriptions. Supports filter: all (mine + shared), mine, shared.
-    Optional recording_type filter: record, whisper."""
-    order = Transcription.created_at.desc() if sort == "newest" else Transcription.created_at.asc()
+    Optional recording_type filter: record, whisper.
+
+    Pinned items always float to the top, regardless of the chosen sort
+    order (Phase 6.2).
+    """
+    secondary = (
+        Transcription.created_at.desc()
+        if sort == "newest"
+        else Transcription.created_at.asc()
+    )
+    order = (Transcription.is_pinned.desc(), secondary)
 
     if current_user.role == UserRole.admin:
         # Admins see everything
-        query = select(Transcription).order_by(order).offset(skip).limit(limit)
+        query = select(Transcription).order_by(*order).offset(skip).limit(limit)
         count_query = select(func.count()).select_from(Transcription)
     else:
         # Get accessible IDs
@@ -321,7 +344,7 @@ async def list_transcriptions(
             query = (
                 select(Transcription)
                 .where(Transcription.user_id == current_user.id)
-                .order_by(order)
+                .order_by(*order)
                 .offset(skip)
                 .limit(limit)
             )
@@ -338,7 +361,7 @@ async def list_transcriptions(
             query = (
                 select(Transcription)
                 .where(Transcription.id.in_(shared_ids))
-                .order_by(order)
+                .order_by(*order)
                 .offset(skip)
                 .limit(limit)
             )
@@ -351,7 +374,7 @@ async def list_transcriptions(
             query = (
                 select(Transcription)
                 .where(Transcription.id.in_(accessible_ids))
-                .order_by(order)
+                .order_by(*order)
                 .offset(skip)
                 .limit(limit)
             )
@@ -1038,3 +1061,237 @@ async def delete_transcription(
         )
 
     await TranscriptionService.delete_transcription(db, transcription_id)
+
+
+
+# ============================================================
+# Phase 6.2 — Pin / unpin
+# ============================================================
+
+
+@router.patch("/{transcription_id}/pin", response_model=TranscriptionResponse)
+async def set_pinned(
+    transcription_id: uuid.UUID,
+    pinned: bool = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Pin or unpin a transcription. Requires write access."""
+    transcription = await TranscriptionService.get_transcription(db, transcription_id)
+    if not transcription:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Transcription not found"
+        )
+
+    has_access = await PermissionService.check_access(
+        db, current_user, ResourceType.transcription, transcription_id, "write"
+    )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to update this transcription",
+        )
+
+    transcription.is_pinned = pinned
+    await db.commit()
+    await db.refresh(transcription)
+    return await _enrich_with_permissions(transcription, current_user, db)
+
+
+# ============================================================
+# Phase 6.3 — Batch operations
+# ============================================================
+
+
+async def _filter_ids_by_permission(
+    db: AsyncSession,
+    user: User,
+    ids: list,
+    required: str = "write",
+):
+    """Return (allowed_ids, skipped_count) for the given operation level."""
+    allowed = []
+    for tid in ids:
+        if await PermissionService.check_access(
+            db, user, ResourceType.transcription, tid, required
+        ):
+            allowed.append(tid)
+    return allowed, len(ids) - len(allowed)
+
+
+@router.post("/batch/delete", response_model=BatchResultResponse)
+async def batch_delete(
+    payload: BatchIdsRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete multiple transcriptions in one call."""
+    if not payload.ids:
+        return BatchResultResponse(affected=0, message="No ids provided")
+
+    deleted = 0
+    skipped = 0
+    for tid in payload.ids:
+        level = await PermissionService.get_permission_level(
+            db, current_user, ResourceType.transcription, tid
+        )
+        if level == "owner":
+            try:
+                await TranscriptionService.delete_transcription(db, tid)
+                deleted += 1
+            except Exception:
+                skipped += 1
+        else:
+            skipped += 1
+
+    return BatchResultResponse(affected=deleted, skipped=skipped)
+
+
+@router.post("/batch/pin", response_model=BatchResultResponse)
+async def batch_pin(
+    payload: BatchPinRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Pin / unpin multiple transcriptions."""
+    if not payload.ids:
+        return BatchResultResponse(affected=0, message="No ids provided")
+
+    allowed, skipped = await _filter_ids_by_permission(db, current_user, payload.ids, "write")
+    if allowed:
+        from sqlalchemy import update as sa_update
+        await db.execute(
+            sa_update(Transcription)
+            .where(Transcription.id.in_(allowed))
+            .values(is_pinned=payload.pinned)
+        )
+        await db.commit()
+    return BatchResultResponse(affected=len(allowed), skipped=skipped)
+
+
+@router.post("/batch/collection", response_model=BatchResultResponse)
+async def batch_set_collection(
+    payload: BatchCollectionRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Move multiple transcriptions into a collection (or out of any)."""
+    if not payload.ids:
+        return BatchResultResponse(affected=0, message="No ids provided")
+
+    if payload.collection_id is not None:
+        coll_result = await db.execute(
+            select(Collection).where(Collection.id == payload.collection_id)
+        )
+        target_collection = coll_result.scalars().first()
+        if not target_collection:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Collection not found"
+            )
+        can_use_collection = await PermissionService.check_access(
+            db, current_user, ResourceType.collection, payload.collection_id, "write"
+        )
+        if not can_use_collection:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not authorized to add to this collection",
+            )
+
+    allowed, skipped = await _filter_ids_by_permission(db, current_user, payload.ids, "write")
+    if allowed:
+        from sqlalchemy import update as sa_update
+        await db.execute(
+            sa_update(Transcription)
+            .where(Transcription.id.in_(allowed))
+            .values(collection_id=payload.collection_id)
+        )
+        await db.commit()
+    return BatchResultResponse(affected=len(allowed), skipped=skipped)
+
+
+@router.post("/batch/share", response_model=BatchResultResponse)
+async def batch_share(
+    payload: BatchShareRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Share multiple owned transcriptions with a group."""
+    if not payload.ids:
+        return BatchResultResponse(affected=0, message="No ids provided")
+
+    if payload.permission not in ("read", "write"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="permission must be 'read' or 'write'",
+        )
+
+    group_result = await db.execute(
+        select(UserGroup).where(UserGroup.id == payload.group_id)
+    )
+    group = group_result.scalars().first()
+    if not group:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Group not found"
+        )
+
+    is_admin = current_user.role == UserRole.admin
+    is_owner = group.owner_id == current_user.id
+    if not (is_admin or is_owner):
+        m_result = await db.execute(
+            select(user_group_members.c.user_id).where(
+                user_group_members.c.group_id == payload.group_id,
+                user_group_members.c.user_id == current_user.id,
+            )
+        )
+        is_member = m_result.scalars().first() is not None
+        if group.sharing_policy == "creator_only" and not is_owner:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="This group only allows its owner to share with it",
+            )
+        if not is_member:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You are not a member of this group",
+            )
+
+    shared = 0
+    skipped = 0
+    perm = (
+        PermissionLevel.write if payload.permission == "write" else PermissionLevel.read
+    )
+    for tid in payload.ids:
+        level = await PermissionService.get_permission_level(
+            db, current_user, ResourceType.transcription, tid
+        )
+        if level != "owner":
+            skipped += 1
+            continue
+
+        existing = await db.execute(
+            select(ResourceShare).where(
+                ResourceShare.resource_type == ResourceType.transcription,
+                ResourceShare.resource_id == tid,
+                ResourceShare.grantee_type == GranteeType.group,
+                ResourceShare.grantee_id == payload.group_id,
+            )
+        )
+        row = existing.scalars().first()
+        if row:
+            row.permission = perm
+            row.granted_by = current_user.id
+        else:
+            db.add(
+                ResourceShare(
+                    resource_type=ResourceType.transcription,
+                    resource_id=tid,
+                    grantee_type=GranteeType.group,
+                    grantee_id=payload.group_id,
+                    permission=perm,
+                    granted_by=current_user.id,
+                )
+            )
+        shared += 1
+
+    await db.commit()
+    return BatchResultResponse(affected=shared, skipped=skipped)

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -352,3 +352,39 @@ async def update_recording_aliases(
     await db.refresh(user)
     logger.info(f"PUT recording-aliases: after commit {user.recording_aliases}")
     return user.recording_aliases or {}
+
+
+
+# Notification preferences (Phase 6.5)
+
+from app.schemas.search import NotificationPreferences  # noqa: E402
+
+
+@router.get("/me/preferences/notifications", response_model=NotificationPreferences)
+async def get_notification_preferences(
+    current_user: User = Depends(get_current_user),
+):
+    """Return the current user's transcription-complete notification preferences."""
+    return NotificationPreferences(
+        notify_on_completion=current_user.notify_on_completion,
+        notify_email_on_completion=current_user.notify_email_on_completion,
+    )
+
+
+@router.put("/me/preferences/notifications", response_model=NotificationPreferences)
+async def update_notification_preferences(
+    prefs: NotificationPreferences,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update the current user's transcription-complete notification preferences."""
+    result = await db.execute(select(User).where(User.id == current_user.id))
+    user = result.scalars().first()
+    user.notify_on_completion = bool(prefs.notify_on_completion)
+    user.notify_email_on_completion = bool(prefs.notify_email_on_completion)
+    await db.commit()
+    await db.refresh(user)
+    return NotificationPreferences(
+        notify_on_completion=user.notify_on_completion,
+        notify_email_on_completion=user.notify_email_on_completion,
+    )

--- a/backend/app/schemas/search.py
+++ b/backend/app/schemas/search.py
@@ -1,0 +1,62 @@
+"""Schemas for the full-text search endpoint (Phase 6.1)."""
+
+from typing import List, Optional
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class SearchHit(BaseModel):
+    """A single search result.
+
+    ``snippet`` is HTML-safe (already escaped by Postgres ``ts_headline``)
+    with ``<mark>`` tags around matched terms.
+    """
+
+    transcription_id: uuid.UUID
+    title: Optional[str] = None
+    original_filename: str
+    recording_type: str
+    status: str
+    snippet: Optional[str] = None
+    rank: float
+    is_pinned: bool = False
+    created_at: datetime
+
+
+class SearchResponse(BaseModel):
+    items: List[SearchHit]
+    total: int
+    query: str
+
+
+class BatchIdsRequest(BaseModel):
+    """Generic batch request — used for delete/pin/move/share."""
+
+    ids: List[uuid.UUID]
+
+
+class BatchPinRequest(BatchIdsRequest):
+    pinned: bool = True
+
+
+class BatchCollectionRequest(BatchIdsRequest):
+    # ``None`` removes the items from any collection.
+    collection_id: Optional[uuid.UUID] = None
+
+
+class BatchShareRequest(BatchIdsRequest):
+    group_id: uuid.UUID
+    permission: str = "read"  # "read" | "write"
+
+
+class BatchResultResponse(BaseModel):
+    affected: int
+    skipped: int = 0
+    message: Optional[str] = None
+
+
+class NotificationPreferences(BaseModel):
+    notify_on_completion: bool = True
+    notify_email_on_completion: bool = False

--- a/backend/app/schemas/transcription.py
+++ b/backend/app/schemas/transcription.py
@@ -80,6 +80,7 @@ class TranscriptionResponse(BaseModel):
     audio_available: bool = False
     auto_summarize: bool = False
     auto_summarize_template_id: Optional[uuid.UUID] = None
+    is_pinned: bool = False
     created_at: datetime
     updated_at: datetime
     # Access control fields (populated by routers, not from DB)
@@ -107,5 +108,4 @@ class PaginatedTranscriptionResponse(BaseModel):
     """Schema for a paginated list of transcriptions."""
     items: List[TranscriptionResponse]
     total: int
-    skip: int
-    limit: int
+  

--- a/backend/app/schemas/transcription.py
+++ b/backend/app/schemas/transcription.py
@@ -108,4 +108,5 @@ class PaginatedTranscriptionResponse(BaseModel):
     """Schema for a paginated list of transcriptions."""
     items: List[TranscriptionResponse]
     total: int
-  
+    skip: int
+    limit: int

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -173,6 +173,63 @@ class EmailService:
         return await EmailService.send_email(db, to_email, subject, html_body, text_body)
 
     @staticmethod
+    async def send_transcription_complete_email(
+        db: AsyncSession,
+        to_email: str,
+        display_name: str,
+        transcription_name: str,
+        transcription_url: str,
+        failed: bool = False,
+        error: Optional[str] = None,
+    ) -> bool:
+        """Phase 6.5 — notify a user that their transcription finished."""
+        if failed:
+            subject = f"Transcription failed — {transcription_name}"
+            heading = "Transcription failed"
+            body_html = (
+                f"<p>“<strong>{transcription_name}</strong>” could not be "
+                f"transcribed.</p>"
+            )
+            if error:
+                body_html += f"<p style='color:#6b7280;font-size:13px;'>{error}</p>"
+            cta = "View details"
+        else:
+            subject = f"Transcription ready — {transcription_name}"
+            heading = "Your transcription is ready"
+            body_html = (
+                f"<p>“<strong>{transcription_name}</strong>” has finished "
+                f"processing and is ready to review.</p>"
+            )
+            cta = "Open transcription"
+
+        html_body = f"""
+        <html>
+        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <div style="background: linear-gradient(135deg, #6366f1, #4f46e5); padding: 30px; border-radius: 12px 12px 0 0; text-align: center;">
+                <h1 style="color: white; margin: 0; font-size: 24px;">OpenHiNotes</h1>
+            </div>
+            <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 12px 12px;">
+                <p style="color: #374151; font-size: 16px;">Hi {display_name or to_email},</p>
+                <h2 style="color: #111827; font-size: 18px; margin: 0 0 12px;">{heading}</h2>
+                {body_html}
+                <div style="text-align: center; margin: 30px 0;">
+                    <a href="{transcription_url}" style="background: #4f46e5; color: white; text-decoration: none; padding: 12px 32px; border-radius: 8px; font-weight: 600; font-size: 14px; display: inline-block;">
+                        {cta}
+                    </a>
+                </div>
+                <p style="color: #9ca3af; font-size: 12px;">You can turn these emails off in Settings → Notifications.</p>
+            </div>
+        </body>
+        </html>
+        """
+        text_body = (
+            f"Hi {display_name or to_email},\n\n{heading}\n\n"
+            f"“{transcription_name}”\n\nOpen: {transcription_url}\n\n"
+            "You can turn these emails off in Settings → Notifications."
+        )
+        return await EmailService.send_email(db, to_email, subject, html_body, text_body)
+
+    @staticmethod
     async def send_account_created_email(
         db: AsyncSession,
         to_email: str,

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1,7 +1,7 @@
 """Tiny helper for creating in-app notifications.
 
 Kept intentionally small — templated notifications for Sprint 6 plus a
-generic `create` for future callers. No email integration here; that can
+generic ``create`` for future callers. No email integration here; that can
 be layered in later by composing this with the existing email service.
 """
 
@@ -83,5 +83,43 @@ async def notify_template_rejected(
         body=body,
         # User lands on their templates; frontend can highlight the rejected one.
         link=f"/templates?focus={template_id}",
+        commit=commit,
+    )
+
+
+async def notify_transcription_completed(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    transcription_id: uuid.UUID,
+    display_name: str,
+    failed: bool = False,
+    error: Optional[str] = None,
+    commit: bool = True,
+) -> Notification:
+    """Phase 6.5 — drop an in-app notification when a transcription
+    finishes processing (success or failure).
+
+    Note: caller is responsible for checking ``user.notify_on_completion``
+    before calling this — keeps preference handling in one place.
+    """
+    if failed:
+        title = "Transcription failed"
+        body = f"“{display_name}” could not be transcribed."
+        if error:
+            body += f" Error: {error}"
+        ntype = "transcription_failed"
+    else:
+        title = "Transcription ready"
+        body = f"“{display_name}” is ready to view."
+        ntype = "transcription_completed"
+
+    return await create_notification(
+        db,
+        user_id=user_id,
+        type=ntype,
+        title=title,
+        body=body,
+        link=f"/transcriptions/{transcription_id}",
         commit=commit,
     )

--- a/backend/app/services/queue.py
+++ b/backend/app/services/queue.py
@@ -15,6 +15,9 @@ from app.services.transcription import TranscriptionService
 from app.services.llm import LLMService
 from app.utils.date_extract import extract_meeting_date
 from app.config import settings
+from app.services.notifications import notify_transcription_completed
+from app.services.email import EmailService, EmailSettingsService
+from app.models.user import User
 
 logger = logging.getLogger(__name__)
 
@@ -158,6 +161,65 @@ class TranscriptionQueue:
                     q.put_nowait(data)
                 except asyncio.QueueFull:
                     pass  # Drop if subscriber is too slow
+
+    async def _send_completion_notification(
+        self,
+        *,
+        transcription_id: uuid.UUID,
+        user_id: uuid.UUID,
+        display_name: str,
+        failed: bool = False,
+        error: Optional[str] = None,
+    ) -> None:
+        """Phase 6.5 — fire an in-app (and optional email) notification
+        when a transcription finishes processing.
+
+        Best-effort: any failure here is logged but never propagated, so
+        the queue worker stays robust.
+        """
+        try:
+            async with AsyncSessionLocal() as db:
+                # Load the owner so we can honour their preferences.
+                user_result = await db.execute(
+                    select(User).where(User.id == user_id)
+                )
+                user = user_result.scalars().first()
+                if not user:
+                    return
+
+                if user.notify_on_completion:
+                    await notify_transcription_completed(
+                        db,
+                        user_id=user_id,
+                        transcription_id=transcription_id,
+                        display_name=display_name,
+                        failed=failed,
+                        error=error,
+                        commit=True,
+                    )
+
+                if user.notify_email_on_completion and user.email:
+                    smtp_ready = await EmailSettingsService.is_configured(db)
+                    if smtp_ready:
+                        base_url = (
+                            getattr(settings, "app_base_url", "") or ""
+                        ).rstrip("/")
+                        link = f"{base_url}/transcriptions/{transcription_id}"
+                        await EmailService.send_transcription_complete_email(
+                            db,
+                            to_email=user.email,
+                            display_name=user.display_name or user.email,
+                            transcription_name=display_name,
+                            transcription_url=link,
+                            failed=failed,
+                            error=error,
+                        )
+        except Exception as e:  # pragma: no cover — best-effort path
+            logger.warning(
+                "Completion notification failed for transcription %s: %s",
+                transcription_id, e,
+            )
+
 
     async def cancel(self, transcription_id: uuid.UUID, user_id: uuid.UUID) -> bool:
         """Cancel a queued or processing transcription. Returns True if cancelled."""
@@ -404,6 +466,14 @@ class TranscriptionQueue:
                     "auto_summarize": will_summarize,
                 })
 
+                # Phase 6.5 — in-app + optional email notification
+                await self._send_completion_notification(
+                    transcription_id=transcription_id,
+                    user_id=user_id,
+                    display_name=orig_filename or stored_filename,
+                    failed=False,
+                )
+
                 # Auto-summarize if requested and transcription produced text
                 if will_summarize:
                     try:
@@ -455,6 +525,16 @@ class TranscriptionQueue:
                     "status": "failed",
                     "error": str(e),
                 })
+
+                # Phase 6.5 — also notify the user when a job fails so
+                # they don't have to keep polling the queue page.
+                await self._send_completion_notification(
+                    transcription_id=transcription_id,
+                    user_id=user_id,
+                    display_name=stored_filename,
+                    failed=True,
+                    error=str(e),
+                )
 
 
 # Singleton instance

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -1,6 +1,11 @@
 import { apiClient } from './client';
 import { AppNotification, NotificationCount } from '@/types';
 
+export interface NotificationPreferences {
+  notify_on_completion: boolean;
+  notify_email_on_completion: boolean;
+}
+
 export const notificationsApi = {
   async list(options: { unreadOnly?: boolean; limit?: number } = {}): Promise<AppNotification[]> {
     const params = new URLSearchParams();
@@ -24,5 +29,14 @@ export const notificationsApi = {
 
   async delete(id: string): Promise<void> {
     return apiClient.delete<void>(`/notifications/${id}`);
+  },
+
+  // Phase 6.5 — per-user transcription-complete preferences.
+  async getPreferences(): Promise<NotificationPreferences> {
+    return apiClient.get<NotificationPreferences>('/users/me/preferences/notifications');
+  },
+
+  async updatePreferences(prefs: NotificationPreferences): Promise<NotificationPreferences> {
+    return apiClient.put<NotificationPreferences>('/users/me/preferences/notifications', prefs);
   },
 };

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -1,0 +1,37 @@
+import { apiClient } from './client';
+import { RecordingType, TranscriptionStatus } from '@/types';
+
+export interface SearchHit {
+  transcription_id: string;
+  title: string | null;
+  original_filename: string;
+  recording_type: RecordingType;
+  status: TranscriptionStatus;
+  snippet: string | null;
+  rank: number;
+  is_pinned: boolean;
+  created_at: string;
+}
+
+export interface SearchResponse {
+  items: SearchHit[];
+  total: number;
+  query: string;
+}
+
+export const searchApi = {
+  async searchTranscriptions(
+    q: string,
+    options: {
+      limit?: number;
+      skip?: number;
+      recordingType?: RecordingType;
+    } = {},
+  ): Promise<SearchResponse> {
+    const params = new URLSearchParams({ q });
+    if (options.limit) params.set('limit', String(options.limit));
+    if (options.skip) params.set('skip', String(options.skip));
+    if (options.recordingType) params.set('recording_type', options.recordingType);
+    return apiClient.get<SearchResponse>(`/search/transcriptions?${params}`);
+  },
+};

--- a/frontend/src/api/transcriptions.ts
+++ b/frontend/src/api/transcriptions.ts
@@ -211,6 +211,48 @@ export const transcriptionsApi = {
     return apiClient.delete<void>(`/transcriptions/${id}`);
   },
 
+  // Phase 6.2 — pinning
+  async setPinned(id: string, pinned: boolean): Promise<Transcription> {
+    return apiClient.patch<Transcription>(`/transcriptions/${id}/pin?pinned=${pinned}`);
+  },
+
+  // Phase 6.3 — batch operations
+  async batchDelete(ids: string[]): Promise<{ affected: number; skipped: number }> {
+    return apiClient.post<{ affected: number; skipped: number }>(
+      '/transcriptions/batch/delete',
+      { ids },
+    );
+  },
+
+  async batchPin(ids: string[], pinned: boolean): Promise<{ affected: number; skipped: number }> {
+    return apiClient.post<{ affected: number; skipped: number }>(
+      '/transcriptions/batch/pin',
+      { ids, pinned },
+    );
+  },
+
+  async batchSetCollection(
+    ids: string[],
+    collectionId: string | null,
+  ): Promise<{ affected: number; skipped: number }> {
+    return apiClient.post<{ affected: number; skipped: number }>(
+      '/transcriptions/batch/collection',
+      { ids, collection_id: collectionId },
+    );
+  },
+
+  async batchShare(
+    ids: string[],
+    groupId: string,
+    permission: 'read' | 'write' = 'read',
+  ): Promise<{ affected: number; skipped: number }> {
+    return apiClient.post<{ affected: number; skipped: number }>(
+      '/transcriptions/batch/share',
+      { ids, group_id: groupId, permission },
+    );
+  },
+
+
   async checkByFilenames(filenames: string[]): Promise<Record<string, { id: string; status: string; title: string | null; keep_audio: boolean; audio_available: boolean }>> {
     if (filenames.length === 0) return {};
     return apiClient.get<Record<string, { id: string; status: string; title: string | null; keep_audio: boolean; audio_available: boolean }>>(

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -1,9 +1,20 @@
 import { useState, useRef, useEffect } from 'react';
-import { Play, Pause, Volume2 } from 'lucide-react';
+import { Play, Pause, Volume2, Keyboard } from 'lucide-react';
 
 interface AudioPlayerProps {
   src: string | Blob;
   fileName: string;
+}
+
+// Phase 6.4 — playback speeds cycled by the "S" shortcut.
+const PLAYBACK_SPEEDS = [1, 1.25, 1.5, 2, 0.75] as const;
+
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName.toLowerCase();
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+  if (target.isContentEditable) return true;
+  return false;
 }
 
 export function AudioPlayer({ src, fileName }: AudioPlayerProps) {
@@ -12,13 +23,13 @@ export function AudioPlayer({ src, fileName }: AudioPlayerProps) {
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
   const [volume, setVolume] = useState(1);
-
+  const [playbackRate, setPlaybackRate] = useState(1);
+  const [showShortcuts, setShowShortcuts] = useState(false);
   const [audioError, setAudioError] = useState<string | null>(null);
 
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio) return;
-
     const handleTimeUpdate = () => setCurrentTime(audio.currentTime);
     const handleLoadedMetadata = () => {
       setDuration(audio.duration);
@@ -32,12 +43,10 @@ export function AudioPlayer({ src, fileName }: AudioPlayerProps) {
       setAudioError(msg);
       setIsPlaying(false);
     };
-
     audio.addEventListener('timeupdate', handleTimeUpdate);
     audio.addEventListener('loadedmetadata', handleLoadedMetadata);
     audio.addEventListener('ended', handleEnded);
     audio.addEventListener('error', handleError);
-
     return () => {
       audio.removeEventListener('timeupdate', handleTimeUpdate);
       audio.removeEventListener('loadedmetadata', handleLoadedMetadata);
@@ -48,14 +57,60 @@ export function AudioPlayer({ src, fileName }: AudioPlayerProps) {
 
   const togglePlay = () => {
     if (audioRef.current) {
-      if (isPlaying) {
-        audioRef.current.pause();
-      } else {
-        audioRef.current.play();
-      }
+      if (isPlaying) audioRef.current.pause();
+      else audioRef.current.play();
       setIsPlaying(!isPlaying);
     }
   };
+
+  const seekBy = (deltaSeconds: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const next = Math.max(0, Math.min(audio.duration || 0, audio.currentTime + deltaSeconds));
+    audio.currentTime = next;
+    setCurrentTime(next);
+  };
+
+  const cycleSpeed = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const idx = PLAYBACK_SPEEDS.indexOf(playbackRate as typeof PLAYBACK_SPEEDS[number]);
+    const next = PLAYBACK_SPEEDS[(idx + 1) % PLAYBACK_SPEEDS.length];
+    audio.playbackRate = next;
+    setPlaybackRate(next);
+  };
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (isEditableTarget(e.target)) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      switch (e.key) {
+        case ' ':
+        case 'Spacebar':
+          e.preventDefault();
+          togglePlay();
+          break;
+        case 'ArrowLeft':
+          e.preventDefault();
+          seekBy(-5);
+          break;
+        case 'ArrowRight':
+          e.preventDefault();
+          seekBy(5);
+          break;
+        case 's':
+        case 'S':
+          e.preventDefault();
+          cycleSpeed();
+          break;
+        default:
+          break;
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPlaying, playbackRate]);
 
   const handleSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newTime = parseFloat(e.target.value);
@@ -67,9 +122,7 @@ export function AudioPlayer({ src, fileName }: AudioPlayerProps) {
 
   const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newVolume = parseFloat(e.target.value);
-    if (audioRef.current) {
-      audioRef.current.volume = newVolume;
-    }
+    if (audioRef.current) audioRef.current.volume = newVolume;
     setVolume(newVolume);
   };
 
@@ -80,7 +133,6 @@ export function AudioPlayer({ src, fileName }: AudioPlayerProps) {
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
-  // Create and revoke object URL properly to avoid memory leaks
   const [audioSrc, setAudioSrc] = useState<string>('');
   useEffect(() => {
     if (typeof src === 'string') {
@@ -96,9 +148,36 @@ export function AudioPlayer({ src, fileName }: AudioPlayerProps) {
     <div className="flex flex-col gap-3 p-4 bg-gray-100 dark:bg-gray-800 rounded-lg">
       <audio ref={audioRef} src={audioSrc} />
 
-      <div className="text-sm font-medium text-gray-700 dark:text-gray-300 truncate">
-        {fileName}
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-sm font-medium text-gray-700 dark:text-gray-300 truncate">
+          {fileName}
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <button
+            onClick={cycleSpeed}
+            title="Playback speed (S)"
+            className="text-xs font-mono px-2 py-1 rounded bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+          >
+            {playbackRate.toFixed(2).replace(/0$/, '')}×
+          </button>
+          <button
+            onClick={() => setShowShortcuts((v) => !v)}
+            title="Keyboard shortcuts"
+            className="p-1.5 rounded text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-white dark:hover:bg-gray-700 transition-colors"
+          >
+            <Keyboard className="w-4 h-4" />
+          </button>
+        </div>
       </div>
+
+      {showShortcuts && (
+        <div className="text-xs text-gray-600 dark:text-gray-400 grid grid-cols-2 gap-x-4 gap-y-1 px-3 py-2 bg-white/60 dark:bg-gray-900/40 rounded border border-gray-200 dark:border-gray-700">
+          <div><kbd className="font-mono">Space</kbd> Play / pause</div>
+          <div><kbd className="font-mono">←</kbd> Back 5 s</div>
+          <div><kbd className="font-mono">→</kbd> Forward 5 s</div>
+          <div><kbd className="font-mono">S</kbd> Cycle speed</div>
+        </div>
+      )}
 
       {audioError && (
         <div className="text-xs text-red-500 bg-red-50 dark:bg-red-900/30 px-3 py-1.5 rounded">
@@ -110,6 +189,7 @@ export function AudioPlayer({ src, fileName }: AudioPlayerProps) {
         <button
           onClick={togglePlay}
           className="p-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+          title="Play / pause (Space)"
         >
           {isPlaying ? (
             <Pause className="w-4 h-4" />

--- a/frontend/src/components/NotificationsBell.tsx
+++ b/frontend/src/components/NotificationsBell.tsx
@@ -6,6 +6,32 @@ import { AppNotification } from '@/types';
 
 const POLL_MS = 30_000;
 
+// Phase 6.5 — kinds of notifications we want to surface as a desktop
+// (browser) notification. Anything else stays bell-only.
+const DESKTOP_TYPES = new Set([
+  'transcription_completed',
+  'transcription_failed',
+]);
+
+function fireBrowserNotification(n: AppNotification, onClick: () => void) {
+  if (typeof window === 'undefined' || !('Notification' in window)) return;
+  if (Notification.permission !== 'granted') return;
+  try {
+    const notif = new Notification(n.title, {
+      body: n.body || undefined,
+      tag: n.id,
+      icon: '/favicon.ico',
+    });
+    notif.onclick = () => {
+      window.focus();
+      onClick();
+      notif.close();
+    };
+  } catch {
+    // Silently ignore — desktop notifications are best-effort.
+  }
+}
+
 export function NotificationsBell() {
   const navigate = useNavigate();
   const [items, setItems] = useState<AppNotification[]>([]);
@@ -14,10 +40,40 @@ export function NotificationsBell() {
   const [isLoading, setIsLoading] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
 
+  // IDs we've already fired desktop notifications for. Persisted across
+  // polls so we don't double-toast the same event.
+  const firedRef = useRef<Set<string>>(new Set());
+  const hasSeededRef = useRef(false);
+
+  const maybeFireDesktopNotifications = async () => {
+    if (typeof window === 'undefined' || !('Notification' in window)) return;
+    if (Notification.permission !== 'granted') return;
+    try {
+      const unreadList = await notificationsApi.list({ unreadOnly: true, limit: 10 });
+      if (!hasSeededRef.current) {
+        unreadList.forEach((n) => firedRef.current.add(n.id));
+        hasSeededRef.current = true;
+        return;
+      }
+      for (const n of unreadList) {
+        if (firedRef.current.has(n.id)) continue;
+        firedRef.current.add(n.id);
+        if (DESKTOP_TYPES.has(n.type)) {
+          fireBrowserNotification(n, () => {
+            if (n.link) navigate(n.link);
+          });
+        }
+      }
+    } catch {
+      // Best-effort — never let this break the polling loop.
+    }
+  };
+
   const refreshCount = async () => {
     try {
       const c = await notificationsApi.count();
       setUnread(c.unread);
+      await maybeFireDesktopNotifications();
     } catch {
       // Silent — notifications are non-critical.
     }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,9 +2,10 @@ import { useState, useEffect } from 'react';
 import { Layout } from '@/components/Layout';
 import { useAuthStore } from '@/store/useAuthStore';
 import { authApi } from '@/api/auth';
-import { Save, Loader, Fingerprint, Lock, CheckCircle, AlertCircle } from 'lucide-react';
+import { Save, Loader, Fingerprint, Lock, CheckCircle, AlertCircle, Bell } from 'lucide-react';
 import { VoiceProfileManager } from '@/components/VoiceProfileManager';
 import { settingsApi } from '@/api/settings';
+import { notificationsApi, NotificationPreferences } from '@/api/notifications';
 
 function ChangePasswordCard() {
   const [isOpen, setIsOpen] = useState(false);
@@ -159,6 +160,148 @@ function ChangePasswordCard() {
   );
 }
 
+
+/**
+ * Phase 6.5 — transcription completion preferences (in-app + email +
+ * desktop browser notifications).
+ */
+function NotificationsCard() {
+  const [prefs, setPrefs] = useState<NotificationPreferences>({
+    notify_on_completion: true,
+    notify_email_on_completion: false,
+  });
+  const [permission, setPermission] = useState<NotificationPermission>(
+    typeof window !== 'undefined' && 'Notification' in window
+      ? Notification.permission
+      : 'denied',
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const p = await notificationsApi.getPreferences();
+        if (!cancelled) setPrefs(p);
+      } catch (err) {
+        console.error('Failed to load notification preferences:', err);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = async (next: NotificationPreferences) => {
+    setIsSaving(true);
+    try {
+      const saved = await notificationsApi.updatePreferences(next);
+      setPrefs(saved);
+      setSavedAt(Date.now());
+    } catch (err) {
+      console.error('Failed to save notification preferences:', err);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const requestPermission = async () => {
+    if (!('Notification' in window)) return;
+    const result = await Notification.requestPermission();
+    setPermission(result);
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
+      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+        <Bell className="w-5 h-5" />
+        Notifications
+      </h2>
+      {isLoading ? (
+        <div className="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-2">
+          <Loader className="w-4 h-4 animate-spin" /> Loading…
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={prefs.notify_on_completion}
+              onChange={(e) =>
+                save({ ...prefs, notify_on_completion: e.target.checked })
+              }
+              className="mt-1 w-4 h-4 text-blue-600 rounded focus:ring-blue-500"
+            />
+            <div>
+              <div className="text-sm font-medium text-gray-900 dark:text-white">
+                Notify me when a transcription completes
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Shows up in the bell menu. Required for desktop notifications.
+              </div>
+            </div>
+          </label>
+
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={prefs.notify_email_on_completion}
+              onChange={(e) =>
+                save({ ...prefs, notify_email_on_completion: e.target.checked })
+              }
+              className="mt-1 w-4 h-4 text-blue-600 rounded focus:ring-blue-500"
+            />
+            <div>
+              <div className="text-sm font-medium text-gray-900 dark:text-white">
+                Also email me when a transcription completes
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Only sent if your admin has configured SMTP for the server.
+              </div>
+            </div>
+          </label>
+
+          <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-medium text-gray-900 dark:text-white">
+                  Desktop notifications
+                </div>
+                <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  Browser permission status: <span className="font-mono">{permission}</span>
+                </div>
+              </div>
+              {permission !== 'granted' && (
+                <button
+                  onClick={requestPermission}
+                  className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+                >
+                  Enable
+                </button>
+              )}
+            </div>
+          </div>
+
+          {isSaving && (
+            <div className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1.5">
+              <Loader className="w-3 h-3 animate-spin" /> Saving…
+            </div>
+          )}
+          {savedAt && !isSaving && (
+            <div className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1.5">
+              <CheckCircle className="w-3 h-3" /> Saved
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function Settings() {
   const { user } = useAuthStore();
   const [displayName, setDisplayName] = useState(user?.display_name || '');
@@ -274,6 +417,8 @@ export function Settings() {
         </div>
 
         <ChangePasswordCard />
+
+        <NotificationsCard />
 
         {/* Voice Fingerprinting */}
         {voiceFingerprintingEnabled && (

--- a/frontend/src/pages/TranscriptionDetail.tsx
+++ b/frontend/src/pages/TranscriptionDetail.tsx
@@ -566,6 +566,69 @@ export function TranscriptionDetail() {
     setVolume(v);
   }, []);
 
+  // Phase 6.4 — keyboard shortcuts on the transcription detail page.
+  // The detail page has its own custom audio element, so we wire the
+  // shortcuts directly into its play/seek/speed handlers. Inactive when
+  // there's no audio or the user is typing into an input/textarea.
+  const PLAYBACK_SPEEDS = [1, 1.25, 1.5, 2, 0.75] as const;
+  const [playbackRate, setPlaybackRate] = useState<number>(1);
+
+  const cyclePlaybackSpeed = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const idx = PLAYBACK_SPEEDS.indexOf(playbackRate as typeof PLAYBACK_SPEEDS[number]);
+    const next = PLAYBACK_SPEEDS[(idx + 1) % PLAYBACK_SPEEDS.length];
+    audio.playbackRate = next;
+    setPlaybackRate(next);
+  }, [playbackRate]);
+
+  useEffect(() => {
+    const isEditable = (el: EventTarget | null) => {
+      if (!(el instanceof HTMLElement)) return false;
+      const tag = el.tagName.toLowerCase();
+      if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+      if (el.isContentEditable) return true;
+      return false;
+    };
+    const handler = (e: KeyboardEvent) => {
+      if (!audioRef.current) return;
+      if (isEditable(e.target)) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const audio = audioRef.current;
+      switch (e.key) {
+        case ' ':
+        case 'Spacebar':
+          e.preventDefault();
+          togglePlayback();
+          break;
+        case 'ArrowLeft': {
+          e.preventDefault();
+          const next = Math.max(0, audio.currentTime - 5);
+          audio.currentTime = next;
+          setPlaybackTime(next);
+          break;
+        }
+        case 'ArrowRight': {
+          e.preventDefault();
+          const max = audio.duration || 0;
+          const next = Math.min(max, audio.currentTime + 5);
+          audio.currentTime = next;
+          setPlaybackTime(next);
+          break;
+        }
+        case 's':
+        case 'S':
+          e.preventDefault();
+          cyclePlaybackSpeed();
+          break;
+        default:
+          break;
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [togglePlayback, cyclePlaybackSpeed]);
+
   const fmtTime = (s: number) => {
     if (!s || !isFinite(s)) return '0:00';
     return `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
@@ -745,8 +808,8 @@ export function TranscriptionDetail() {
               </span>
             )}
 
-            {/* Pin toggle (anyone with write access) */}
-            {(isOwner || permissionLevel === 'write') && (
+            {/* Pin toggle (anyone who can view) */}
+            {permissionLevel && (
               <button
                 onClick={async () => {
                   try {
@@ -927,7 +990,7 @@ export function TranscriptionDetail() {
                     {fmtTime(playbackTime)} / {fmtTime(audioDuration)}
                   </span>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 flex-wrap">
                   <Volume2 className="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
                   <input
                     type="range"
@@ -938,6 +1001,16 @@ export function TranscriptionDetail() {
                     onChange={handleVolumeChange}
                     className="w-24 h-1.5 bg-gray-200 dark:bg-gray-600 rounded-lg appearance-none cursor-pointer accent-primary-600"
                   />
+                  <button
+                    onClick={cyclePlaybackSpeed}
+                    title="Playback speed (press S)"
+                    className="text-[11px] font-mono px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  >
+                    {playbackRate.toFixed(2).replace(/0$/, '')}×
+                  </button>
+                  <span className="text-[10px] text-gray-400 dark:text-gray-500 ml-1 hidden sm:inline">
+                    <kbd>Space</kbd> play · <kbd>←/→</kbd> 5s · <kbd>S</kbd> speed
+                  </span>
                   {isPlaying && (
                     <span className="ml-2 inline-flex items-center gap-1 text-[10px] font-medium text-primary-600 dark:text-primary-400">
                       <Disc3 className="w-3 h-3 animate-spin" />

--- a/frontend/src/pages/TranscriptionDetail.tsx
+++ b/frontend/src/pages/TranscriptionDetail.tsx
@@ -13,7 +13,7 @@ import { useDeviceConnection } from '@/hooks/useDeviceConnection';
 import { deviceService } from '@/services/deviceService';
 import { Transcription, Summary, SummaryTemplate, Collection } from '@/types';
 import { format } from 'date-fns';
-import { Save, Loader, Plus, Pencil, Trash2, X, FileText, Maximize2, Download, Play, Pause, Volume2, Disc3, Share2, Lock, Eye, ChevronDown } from 'lucide-react';
+import { Save, Loader, Plus, Pencil, Trash2, X, FileText, Maximize2, Download, Play, Pause, Volume2, Disc3, Share2, Lock, Eye, ChevronDown, Pin } from 'lucide-react';
 import { ShareModal } from '@/components/ShareModal';
 import { InteractiveMarkdown } from '@/components/InteractiveMarkdown';
 import { TemplateSelector } from '@/components/TemplateSelector';
@@ -743,6 +743,32 @@ export function TranscriptionDetail() {
                   <><Pencil className="w-3 h-3" /> Can edit</>
                 )}
               </span>
+            )}
+
+            {/* Pin toggle (anyone with write access) */}
+            {(isOwner || permissionLevel === 'write') && (
+              <button
+                onClick={async () => {
+                  try {
+                    const updated = await transcriptionsApi.setPinned(
+                      transcription.id,
+                      !transcription.is_pinned,
+                    );
+                    setTranscription(updated);
+                  } catch (err) {
+                    console.error('Failed to toggle pin:', err);
+                  }
+                }}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+                  transcription.is_pinned
+                    ? 'text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 hover:bg-amber-100 dark:hover:bg-amber-900/30'
+                    : 'text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
+                }`}
+                title={transcription.is_pinned ? 'Unpin' : 'Pin to top of lists'}
+              >
+                <Pin className="w-3.5 h-3.5" />
+                {transcription.is_pinned ? 'Pinned' : 'Pin'}
+              </button>
             )}
 
             {/* Share button (owner only) */}

--- a/frontend/src/pages/Transcriptions.tsx
+++ b/frontend/src/pages/Transcriptions.tsx
@@ -4,11 +4,12 @@ import { Layout } from '@/components/Layout';
 import { transcriptionsApi } from '@/api/transcriptions';
 import { searchApi, SearchHit } from '@/api/search';
 import { useAppStore } from '@/store/useAppStore';
-import { Transcription } from '@/types';
+import { Transcription, RecordingType } from '@/types';
 import { format } from 'date-fns';
 import {
   Trash2, CheckCircle, AlertCircle, Loader, Search, RefreshCw, FileText,
   Inbox, Clock, Unplug, ArrowUpDown, Pin, PinOff, X, CheckSquare, Square,
+  Mic, MessageSquare,
 } from 'lucide-react';
 
 export function Transcriptions() {
@@ -20,6 +21,7 @@ export function Transcriptions() {
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [sortOrder, setSortOrder] = useState<'newest' | 'oldest'>('newest');
   const [ownershipFilter, setOwnershipFilter] = useState<'all' | 'mine' | 'shared'>('all');
+  const [typeFilter, setTypeFilter] = useState<'all' | RecordingType>('all');
 
   // Phase 6.1 — server-side full-text search.
   const [serverHits, setServerHits] = useState<SearchHit[] | null>(null);
@@ -37,12 +39,15 @@ export function Transcriptions() {
   useEffect(() => {
     loadTranscriptions();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sortOrder, ownershipFilter]);
+  }, [sortOrder, ownershipFilter, typeFilter]);
 
   const loadTranscriptions = async () => {
     setIsLoading(true);
     try {
-      const response = await transcriptionsApi.getTranscriptions(0, 100, sortOrder, ownershipFilter);
+      const response = await transcriptionsApi.getTranscriptions(
+        0, 100, sortOrder, ownershipFilter,
+        typeFilter === 'all' ? undefined : typeFilter,
+      );
       setTranscriptions(response.items);
     } catch (error) {
       console.error('Failed to load transcriptions:', error);
@@ -66,7 +71,10 @@ export function Transcriptions() {
       const controller = new AbortController();
       searchAbortRef.current = controller;
       try {
-        const res = await searchApi.searchTranscriptions(q, { limit: 50 });
+        const res = await searchApi.searchTranscriptions(q, {
+          limit: 50,
+          recordingType: typeFilter === 'all' ? undefined : typeFilter,
+        });
         if (!controller.signal.aborted) setServerHits(res.items);
       } catch (err) {
         if (!controller.signal.aborted) {
@@ -81,7 +89,7 @@ export function Transcriptions() {
       clearTimeout(handle);
       searchAbortRef.current?.abort?.();
     };
-  }, [searchTerm]);
+  }, [searchTerm, typeFilter]);
 
   const visibleTranscriptions: Transcription[] = useMemo(() => {
     let list = transcriptions;
@@ -238,6 +246,29 @@ export function Transcriptions() {
             ))}
           </div>
 
+          {/* Phase 6 follow-up — record / whisper filter */}
+          <div className="inline-flex rounded-xl border border-gray-200/60 dark:border-gray-700/40 overflow-hidden">
+            {([
+              { key: 'all',     label: 'All',      icon: null },
+              { key: 'record',  label: 'Records',  icon: <Mic className="w-3.5 h-3.5" /> },
+              { key: 'whisper', label: 'Whispers', icon: <MessageSquare className="w-3.5 h-3.5" /> },
+            ] as const).map((f) => (
+              <button
+                key={f.key}
+                onClick={() => setTypeFilter(f.key)}
+                className={`inline-flex items-center gap-1.5 px-3 py-2.5 text-sm font-medium transition-colors ${
+                  typeFilter === f.key
+                    ? 'bg-primary-500 text-white'
+                    : 'bg-white/80 dark:bg-gray-800/80 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
+                }`}
+                title={f.key === 'all' ? 'Show both records and whispers' : `Show only ${f.label.toLowerCase()}`}
+              >
+                {f.icon}
+                {f.label}
+              </button>
+            ))}
+          </div>
+
           <button
             onClick={() => setSortOrder(sortOrder === 'newest' ? 'oldest' : 'newest')}
             className="inline-flex items-center gap-2 px-4 py-2.5 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm text-gray-700 dark:text-gray-300 border border-gray-200/60 dark:border-gray-700/40 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200"
@@ -357,6 +388,21 @@ export function Transcriptions() {
                             <div className="min-w-0">
                               <div className="flex items-center gap-2">
                                 {t.is_pinned && (<Pin className="w-3.5 h-3.5 text-amber-500 flex-shrink-0" />)}
+                                {t.recording_type === 'whisper' ? (
+                                  <span
+                                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300 flex-shrink-0"
+                                    title="Whisper note"
+                                  >
+                                    <MessageSquare className="w-3 h-3" /> Whisper
+                                  </span>
+                                ) : (
+                                  <span
+                                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300 flex-shrink-0"
+                                    title="Recorded conversation"
+                                  >
+                                    <Mic className="w-3 h-3" /> Record
+                                  </span>
+                                )}
                                 <span className="font-medium text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors duration-150 truncate">
                                   {t.title || t.original_filename}
                                 </span>

--- a/frontend/src/pages/Transcriptions.tsx
+++ b/frontend/src/pages/Transcriptions.tsx
@@ -1,22 +1,14 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Layout } from '@/components/Layout';
 import { transcriptionsApi } from '@/api/transcriptions';
+import { searchApi, SearchHit } from '@/api/search';
 import { useAppStore } from '@/store/useAppStore';
 import { Transcription } from '@/types';
 import { format } from 'date-fns';
 import {
-  Trash2,
-  CheckCircle,
-  AlertCircle,
-  Loader,
-  Search,
-  RefreshCw,
-  FileText,
-  Inbox,
-  Clock,
-  Unplug,
-  ArrowUpDown,
+  Trash2, CheckCircle, AlertCircle, Loader, Search, RefreshCw, FileText,
+  Inbox, Clock, Unplug, ArrowUpDown, Pin, PinOff, X, CheckSquare, Square,
 } from 'lucide-react';
 
 export function Transcriptions() {
@@ -29,7 +21,14 @@ export function Transcriptions() {
   const [sortOrder, setSortOrder] = useState<'newest' | 'oldest'>('newest');
   const [ownershipFilter, setOwnershipFilter] = useState<'all' | 'mine' | 'shared'>('all');
 
-  // Set of filenames currently on the device — used to detect orphaned transcriptions
+  // Phase 6.1 — server-side full-text search.
+  const [serverHits, setServerHits] = useState<SearchHit[] | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+
+  // Phase 6.3 — multi-select state.
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
   const deviceFileNames = useMemo(
     () => new Set(recordings.map((r) => r.fileName)),
     [recordings],
@@ -37,6 +36,7 @@ export function Transcriptions() {
 
   useEffect(() => {
     loadTranscriptions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortOrder, ownershipFilter]);
 
   const loadTranscriptions = async () => {
@@ -51,6 +51,60 @@ export function Transcriptions() {
     }
   };
 
+  // Phase 6.1 — debounced server search effect.
+  const searchAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => {
+    const q = searchTerm.trim();
+    if (q.length < 2) {
+      setServerHits(null);
+      setIsSearching(false);
+      return;
+    }
+    setIsSearching(true);
+    const handle = setTimeout(async () => {
+      searchAbortRef.current?.abort?.();
+      const controller = new AbortController();
+      searchAbortRef.current = controller;
+      try {
+        const res = await searchApi.searchTranscriptions(q, { limit: 50 });
+        if (!controller.signal.aborted) setServerHits(res.items);
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          console.error('Search failed:', err);
+          setServerHits([]);
+        }
+      } finally {
+        if (!controller.signal.aborted) setIsSearching(false);
+      }
+    }, 250);
+    return () => {
+      clearTimeout(handle);
+      searchAbortRef.current?.abort?.();
+    };
+  }, [searchTerm]);
+
+  const visibleTranscriptions: Transcription[] = useMemo(() => {
+    let list = transcriptions;
+    if (serverHits) {
+      const hitIds = new Set(serverHits.map((h) => h.transcription_id));
+      list = list.filter((t) => hitIds.has(t.id));
+    } else {
+      const lowered = searchTerm.toLowerCase();
+      list = transcriptions.filter((t) => {
+        const target = (t.title || t.original_filename).toLowerCase();
+        return target.includes(lowered) || t.original_filename.toLowerCase().includes(lowered);
+      });
+    }
+    if (statusFilter !== 'all') list = list.filter((t) => t.status === statusFilter);
+    return list;
+  }, [transcriptions, serverHits, searchTerm, statusFilter]);
+
+  const snippetById = useMemo(() => {
+    const m = new Map<string, string>();
+    serverHits?.forEach((h) => { if (h.snippet) m.set(h.transcription_id, h.snippet); });
+    return m;
+  }, [serverHits]);
+
   const handleDelete = async (id: string) => {
     if (window.confirm('Delete this transcription?')) {
       try {
@@ -62,55 +116,98 @@ export function Transcriptions() {
     }
   };
 
+  const togglePin = useCallback(async (t: Transcription) => {
+    try {
+      const updated = await transcriptionsApi.setPinned(t.id, !t.is_pinned);
+      setTranscriptions((prev) => prev.map((x) => (x.id === t.id ? updated : x)));
+    } catch (err) {
+      console.error('Failed to update pin state:', err);
+    }
+  }, []);
+
+  const toggleSelection = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const exitSelectionMode = () => {
+    setSelectionMode(false);
+    setSelectedIds(new Set());
+  };
+
+  const selectAll = () => {
+    setSelectedIds(new Set(visibleTranscriptions.map((t) => t.id)));
+  };
+
+  const handleBatchDelete = async () => {
+    const ids = Array.from(selectedIds);
+    if (!ids.length) return;
+    if (!window.confirm(`Delete ${ids.length} transcription${ids.length > 1 ? 's' : ''}?`)) return;
+    try {
+      const result = await transcriptionsApi.batchDelete(ids);
+      setTranscriptions((prev) => prev.filter((t) => !selectedIds.has(t.id)));
+      if (result.skipped > 0) {
+        alert(`${result.affected} deleted, ${result.skipped} skipped (no permission).`);
+      }
+    } catch (err) {
+      console.error('Batch delete failed:', err);
+    } finally {
+      exitSelectionMode();
+    }
+  };
+
+  const handleBatchPin = async (pinned: boolean) => {
+    const ids = Array.from(selectedIds);
+    if (!ids.length) return;
+    try {
+      await transcriptionsApi.batchPin(ids, pinned);
+      setTranscriptions((prev) => prev.map((t) => (selectedIds.has(t.id) ? { ...t, is_pinned: pinned } : t)));
+    } catch (err) {
+      console.error('Batch pin failed:', err);
+    } finally {
+      exitSelectionMode();
+    }
+  };
+
   const getStatusIcon = (status: string) => {
     switch (status) {
-      case 'completed':
-        return <CheckCircle className="w-3.5 h-3.5" />;
-      case 'processing':
-        return <Loader className="w-3.5 h-3.5 animate-spin" />;
-      case 'failed':
-        return <AlertCircle className="w-3.5 h-3.5" />;
-      default:
-        return <Clock className="w-3.5 h-3.5" />;
+      case 'completed': return <CheckCircle className="w-3.5 h-3.5" />;
+      case 'processing': return <Loader className="w-3.5 h-3.5 animate-spin" />;
+      case 'failed': return <AlertCircle className="w-3.5 h-3.5" />;
+      default: return <Clock className="w-3.5 h-3.5" />;
     }
   };
 
   const getStatusBadge = (status: string) => {
     const base = 'inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium transition-colors duration-150';
     switch (status) {
-      case 'completed':
-        return `${base} bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400`;
-      case 'processing':
-        return `${base} bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400`;
-      case 'failed':
-        return `${base} bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400`;
-      default:
-        return `${base} bg-gray-100 text-gray-600 dark:bg-gray-700/50 dark:text-gray-400`;
+      case 'completed': return `${base} bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400`;
+      case 'processing': return `${base} bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400`;
+      case 'failed': return `${base} bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400`;
+      default: return `${base} bg-gray-100 text-gray-600 dark:bg-gray-700/50 dark:text-gray-400`;
     }
   };
-
-  const filteredTranscriptions = transcriptions.filter((t) => {
-    const searchTarget = (t.title || t.original_filename).toLowerCase();
-    const matchesSearch = searchTarget.includes(searchTerm.toLowerCase()) ||
-      t.original_filename.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesStatus = statusFilter === 'all' || t.status === statusFilter;
-    return matchesSearch && matchesStatus;
-  });
 
   return (
     <Layout title="Transcriptions">
       <div className="space-y-6">
-        {/* Search & Filter Bar */}
         <div className="flex flex-col md:flex-row gap-3">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-gray-500" />
             <input
               type="text"
-              placeholder="Search transcriptions..."
+              placeholder="Search title, filename, or transcript text…"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2.5 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm text-gray-900 dark:text-white border border-gray-200/60 dark:border-gray-700/40 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500/50 focus:border-primary-500 transition-all duration-200"
+              className="w-full pl-10 pr-10 py-2.5 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm text-gray-900 dark:text-white border border-gray-200/60 dark:border-gray-700/40 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500/50 focus:border-primary-500 transition-all duration-200"
             />
+            {isSearching && (
+              <Loader className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 animate-spin" />
+            )}
           </div>
 
           <select
@@ -125,7 +222,6 @@ export function Transcriptions() {
             <option value="failed">Failed</option>
           </select>
 
-          {/* Ownership filter */}
           <div className="inline-flex rounded-xl border border-gray-200/60 dark:border-gray-700/40 overflow-hidden">
             {(['all', 'mine', 'shared'] as const).map((f) => (
               <button
@@ -145,10 +241,21 @@ export function Transcriptions() {
           <button
             onClick={() => setSortOrder(sortOrder === 'newest' ? 'oldest' : 'newest')}
             className="inline-flex items-center gap-2 px-4 py-2.5 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm text-gray-700 dark:text-gray-300 border border-gray-200/60 dark:border-gray-700/40 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200"
-            title={`Sort by date: ${sortOrder === 'newest' ? 'Newest first' : 'Oldest first'}`}
           >
             <ArrowUpDown className="w-4 h-4" />
             <span className="text-sm">{sortOrder === 'newest' ? 'Newest' : 'Oldest'}</span>
+          </button>
+
+          <button
+            onClick={() => (selectionMode ? exitSelectionMode() : setSelectionMode(true))}
+            className={`inline-flex items-center gap-2 px-4 py-2.5 backdrop-blur-sm border rounded-xl transition-all duration-200 ${
+              selectionMode
+                ? 'bg-primary-500 text-white border-primary-500'
+                : 'bg-white/80 dark:bg-gray-800/80 text-gray-700 dark:text-gray-300 border-gray-200/60 dark:border-gray-700/40 hover:bg-gray-100 dark:hover:bg-gray-700'
+            }`}
+          >
+            <CheckSquare className="w-4 h-4" />
+            <span className="text-sm">{selectionMode ? 'Cancel' : 'Select'}</span>
           </button>
 
           <button
@@ -161,14 +268,37 @@ export function Transcriptions() {
           </button>
         </div>
 
-        {/* Transcriptions Table */}
+        {selectionMode && (
+          <div className="flex flex-wrap items-center gap-2 px-4 py-3 bg-primary-50 dark:bg-primary-900/20 border border-primary-200 dark:border-primary-800 rounded-xl">
+            <span className="text-sm text-primary-700 dark:text-primary-300 font-medium">
+              {selectedIds.size} selected
+            </span>
+            <button onClick={selectAll} className="text-xs px-3 py-1.5 rounded-lg bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700">
+              Select all visible
+            </button>
+            <span className="flex-1" />
+            <button onClick={() => handleBatchPin(true)} disabled={!selectedIds.size} className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50">
+              <Pin className="w-3.5 h-3.5" /> Pin
+            </button>
+            <button onClick={() => handleBatchPin(false)} disabled={!selectedIds.size} className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50">
+              <PinOff className="w-3.5 h-3.5" /> Unpin
+            </button>
+            <button onClick={handleBatchDelete} disabled={!selectedIds.size} className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-red-500 text-white hover:bg-red-600 disabled:opacity-50">
+              <Trash2 className="w-3.5 h-3.5" /> Delete
+            </button>
+            <button onClick={exitSelectionMode} className="p-1.5 rounded-lg text-gray-500 hover:bg-white dark:hover:bg-gray-800">
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+
         <div className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-xl border border-gray-200/60 dark:border-gray-700/40 shadow-sm overflow-hidden">
           {isLoading ? (
             <div className="p-16 text-center">
               <Loader className="w-8 h-8 text-primary-500 animate-spin mx-auto mb-3" />
               <p className="text-gray-500 dark:text-gray-400 text-sm">Loading transcriptions...</p>
             </div>
-          ) : filteredTranscriptions.length === 0 ? (
+          ) : visibleTranscriptions.length === 0 ? (
             <div className="p-16 text-center">
               <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-700/50 mb-4">
                 {transcriptions.length === 0 ? (
@@ -178,9 +308,7 @@ export function Transcriptions() {
                 )}
               </div>
               <p className="text-gray-600 dark:text-gray-300 font-medium mb-1">
-                {transcriptions.length === 0
-                  ? 'No transcriptions yet'
-                  : 'No matching transcriptions'}
+                {transcriptions.length === 0 ? 'No transcriptions yet' : 'No matching transcriptions'}
               </p>
               <p className="text-gray-500 dark:text-gray-400 text-sm">
                 {transcriptions.length === 0
@@ -193,88 +321,88 @@ export function Transcriptions() {
               <table className="w-full">
                 <thead className="bg-gray-50/80 dark:bg-gray-700/50">
                   <tr>
-                    <th className="px-6 py-3.5 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">
-                      Name
-                    </th>
-                    <th className="px-6 py-3.5 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">
-                      Language
-                    </th>
-                    <th className="px-6 py-3.5 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">
-                      Duration
-                    </th>
-                    <th className="px-6 py-3.5 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">
-                      Date
-                    </th>
-                    <th className="px-6 py-3.5 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">
-                      Status
-                    </th>
-                    <th className="px-6 py-3.5 text-right text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">
-                      Actions
-                    </th>
+                    {selectionMode && <th className="px-3 py-3.5 w-10"></th>}
+                    <th className="px-6 py-3.5 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Name</th>
+                    <th className="px-6 py-3.5 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Language</th>
+                    <th className="px-6 py-3.5 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Duration</th>
+                    <th className="px-6 py-3.5 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Date</th>
+                    <th className="px-6 py-3.5 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                    <th className="px-6 py-3.5 text-right text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Actions</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-100 dark:divide-gray-700/50">
-                  {filteredTranscriptions.map((t) => (
-                    <tr
-                      key={t.id}
-                      className="group hover:bg-primary-50/50 dark:hover:bg-primary-900/10 transition-all duration-150 cursor-pointer"
-                      onClick={() => navigate(`/transcriptions/${t.id}`)}
-                    >
-                      <td className="px-6 py-4 text-sm">
-                        <div className="flex items-center gap-3">
-                          <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center">
-                            <FileText className="w-4 h-4 text-primary-600 dark:text-primary-400" />
-                          </div>
-                          <div className="min-w-0">
-                            <div className="flex items-center gap-2">
-                              <span className="font-medium text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors duration-150 truncate">
-                                {t.title || t.original_filename}
-                              </span>
-                              {deviceFileNames.size > 0 && !deviceFileNames.has(t.original_filename) && (
-                                <span
-                                  className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 flex-shrink-0"
-                                  title="Source recording no longer on device"
-                                >
-                                  <Unplug className="w-3 h-3" />
-                                  Orphan
+                  {visibleTranscriptions.map((t) => {
+                    const isSelected = selectedIds.has(t.id);
+                    const snippet = snippetById.get(t.id);
+                    return (
+                      <tr
+                        key={t.id}
+                        className={`group transition-all duration-150 cursor-pointer ${
+                          isSelected ? 'bg-primary-50 dark:bg-primary-900/20' : 'hover:bg-primary-50/50 dark:hover:bg-primary-900/10'
+                        }`}
+                        onClick={() => selectionMode ? toggleSelection(t.id) : navigate(`/transcriptions/${t.id}`)}
+                      >
+                        {selectionMode && (
+                          <td className="px-3 py-4">
+                            <button onClick={(e) => { e.stopPropagation(); toggleSelection(t.id); }} className="p-1 text-primary-600 dark:text-primary-400">
+                              {isSelected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4" />}
+                            </button>
+                          </td>
+                        )}
+                        <td className="px-6 py-4 text-sm">
+                          <div className="flex items-center gap-3">
+                            <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center">
+                              <FileText className="w-4 h-4 text-primary-600 dark:text-primary-400" />
+                            </div>
+                            <div className="min-w-0">
+                              <div className="flex items-center gap-2">
+                                {t.is_pinned && (<Pin className="w-3.5 h-3.5 text-amber-500 flex-shrink-0" />)}
+                                <span className="font-medium text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors duration-150 truncate">
+                                  {t.title || t.original_filename}
                                 </span>
+                                {deviceFileNames.size > 0 && !deviceFileNames.has(t.original_filename) && (
+                                  <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 flex-shrink-0" title="Source recording no longer on device">
+                                    <Unplug className="w-3 h-3" />
+                                    Orphan
+                                  </span>
+                                )}
+                              </div>
+                              {t.title && (<span className="text-xs text-gray-500 dark:text-gray-400 block truncate">{t.original_filename}</span>)}
+                              {snippet && (
+                                <span className="text-xs text-gray-500 dark:text-gray-400 block mt-1 leading-snug" dangerouslySetInnerHTML={{ __html: snippet }} />
                               )}
                             </div>
-                            {t.title && (
-                              <span className="text-xs text-gray-500 dark:text-gray-400 block truncate">
-                                {t.original_filename}
-                              </span>
-                            )}
                           </div>
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 uppercase">
-                        {t.language}
-                      </td>
-                      <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
-                        {t.audio_duration
-                          ? `${Math.ceil(t.audio_duration / 60)} min`
-                          : '-'}
-                      </td>
-                      <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
-                        {format(new Date(t.created_at), 'MMM d, yyyy')}
-                      </td>
-                      <td className="px-6 py-4 text-sm">
-                        <span className={getStatusBadge(t.status)}>
-                          {getStatusIcon(t.status)}
-                          <span className="capitalize">{t.status}</span>
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 text-right" onClick={(e) => e.stopPropagation()}>
-                        <button
-                          onClick={() => handleDelete(t.id)}
-                          className="p-2 hover:bg-red-100 dark:hover:bg-red-900/30 rounded-lg text-gray-400 hover:text-red-600 dark:text-gray-500 dark:hover:text-red-400 transition-all duration-200 opacity-0 group-hover:opacity-100"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
+                        </td>
+                        <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 uppercase">{t.language}</td>
+                        <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">{t.audio_duration ? `${Math.ceil(t.audio_duration / 60)} min` : '-'}</td>
+                        <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">{format(new Date(t.created_at), 'MMM d, yyyy')}</td>
+                        <td className="px-6 py-4 text-sm">
+                          <span className={getStatusBadge(t.status)}>
+                            {getStatusIcon(t.status)}
+                            <span className="capitalize">{t.status}</span>
+                          </span>
+                        </td>
+                        <td className="px-6 py-4 text-right" onClick={(e) => e.stopPropagation()}>
+                          <div className="inline-flex items-center gap-1">
+                            <button
+                              onClick={() => togglePin(t)}
+                              title={t.is_pinned ? 'Unpin' : 'Pin to top'}
+                              className={`p-2 rounded-lg transition-all duration-200 ${
+                                t.is_pinned ? 'text-amber-500 hover:bg-amber-100 dark:hover:bg-amber-900/30'
+                                  : 'text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-amber-500 opacity-0 group-hover:opacity-100'
+                              }`}
+                            >
+                              <Pin className="w-4 h-4" />
+                            </button>
+                            <button onClick={() => handleDelete(t.id)} className="p-2 hover:bg-red-100 dark:hover:bg-red-900/30 rounded-lg text-gray-400 hover:text-red-600 dark:text-gray-500 dark:hover:text-red-400 transition-all duration-200 opacity-0 group-hover:opacity-100">
+                              <Trash2 className="w-4 h-4" />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -83,6 +83,7 @@ export interface Transcription {
   audio_available: boolean;
   auto_summarize: boolean;
   auto_summarize_template_id: string | null;
+  is_pinned: boolean;
   created_at: string;
   updated_at: string;
   permission_level?: PermissionLevel | null;


### PR DESCRIPTION
## Phase 6 — Quality of Life

Implements roadmap items 6.1 → 6.5 in a single PR. The notification scaffold from Phase 4 (model, router, bell) is reused; 6.5 adds the missing trigger, email path, browser-push surface, and per-user preferences.

### What's in

**6.1 Full-text search**
- Postgres `tsvector` GIN expression index on `coalesce(title,'') || ' ' || coalesce(text,'')` (simple dictionary so it works across locales without per-row language detection)
- `GET /api/search/transcriptions?q=…&limit=…&recording_type=…` returning ranked hits with `ts_headline` snippets wrapped in `<mark>`
- Permission-scoped via the existing `PermissionService.list_accessible_ids` — non-admins only see what they can read
- Frontend: debounced (250 ms) search bar replaces the local title filter once the query is ≥ 2 chars, snippets render under matching rows

**6.2 Favorites / pinning**
- `is_pinned` boolean column on `transcriptions`, partial index for cheap "pinned-first" sorts
- `PATCH /api/transcriptions/{id}/pin?pinned=…` 
- List endpoint now sorts `is_pinned DESC` ahead of the user's chosen newest/oldest order
- Per-row pin button on the Transcriptions page, pinned-state badge on the detail page

**6.3 Batch operations**
- Multi-select mode on the Transcriptions page with bulk Pin / Unpin / Delete in the action bar
- `POST /api/transcriptions/batch/delete | /batch/pin | /batch/collection | /batch/share` — each returns `{affected, skipped}`. Permission checks per id; non-owned items are silently skipped and reported
- Group sharing honours the existing `sharing_policy` (creator_only blocks non-owner members)

**6.4 Keyboard shortcuts on the audio player**
- Space play/pause, ←/→ seek ±5 s, S cycles speed (1× → 1.25× → 1.5× → 2× → 0.75×)
- Inert when focus is inside an `<input>` / `<textarea>` / contenteditable, and when any modifier is held — won't fight transcript editing or browser shortcuts
- "?" / keyboard icon in the player exposes the shortcut list

**6.5 Transcription-complete notifications**
- In-app: queue worker fires `notify_transcription_completed` on success and failure (covered both code paths)
- Email: new `EmailService.send_transcription_complete_email` template; only sent when SMTP is configured AND the user opted in
- Desktop / browser: `NotificationsBell` polls for new unread, fires `new Notification(title, { body, tag, icon })` for `transcription_completed` / `transcription_failed` types. A seed pass on first poll prevents existing unread items from re-toasting
- Per-user prefs: `notify_on_completion` and `notify_email_on_completion` on `users`, exposed via `GET/PUT /api/users/me/preferences/notifications` and a Settings → Notifications card (with a "Enable" button for the browser permission)
- New `app_base_url` setting so email CTAs deep-link back to the transcript

## Fixes
- Transcriptions page: filter chips for All/Records/Whispers, type badge per row
- TranscriptionDetail: Space/Arrow/S shortcuts + speed indicator (detail page has its
  own audio element, AudioPlayer-level shortcuts didn't apply)

### Migration

Single new revision: `025_phase6_search_pin_prefs` (down_revision = `024_template_manager_role`). Adds `transcriptions.is_pinned`, the GIN expression index, `users.notify_on_completion`, `users.notify_email_on_completion`, plus the partial pin index. Clean downgrade.

> ⚠️ **Heads-up for existing deployments**: if your DB has been running for a while, `alembic_version` may be behind the schema (because `Base.metadata.create_all` ran at startup and created tables Alembic never tracked). Before deploying, verify `alembic current` matches reality. If it lags, stamp to `024_template_manager_role` (after manually adding any missed columns) then `alembic upgrade head`. Fresh deployments are unaffected.

### Test checklist

**Search (6.1)**
- [x] Server search returns hits with `<mark>` snippets for terms in transcript body
- [x] Queries < 2 chars use the local title/filename filter (no network call)
- [x] Non-admin sees only accessible transcripts; admin sees everything
- [x] `GET /api/search/transcriptions?q=foo&recording_type=whisper` filters by type

**Pinning (6.2)**
- [x] Pin button on detail page toggles state, persists across reload
- [x] Pinned transcripts float to top of list regardless of newest/oldest sort
- [x] Read-only shared items don't expose pin button

**Batch (6.3)**
- [x] "Select" toggles selection mode; row click toggles checkbox
- [x] Batch pin / unpin / delete all work; non-owned items reported as `skipped`
- [x] Batch share to a `creator_only` group denied for non-owners

**Shortcuts (6.4)**
- [x] Space / ←/→ / S work on detail page with audio
- [x] Shortcuts inert in input/textarea/contenteditable and with modifier keys
- [x] Speed indicator + shortcut hint visible in player header

**Notifications (6.5)**
- [x] Completing a transcription → bell entry "Transcription ready"
- [x] Failure → bell entry "Transcription failed" with error
- [x] Settings → Notifications: toggles persist; "Enable" prompts for browser permission
- [x] With permission granted, a desktop toast fires on next completion (and clicking it navigates to the transcript)
- [x] Pre-existing unread items do NOT re-toast (seed pass)
- [x] `notify_on_completion = false` suppresses both bell and email
- [x] With SMTP unconfigured, no email is sent and no error is thrown

**Regression**
- [x] List endpoint pinned-first ordering doesn't break shared/mine filtering
- [ ] Template review flow still works
- [x] Audio player core playback (load, scrub, volume) unchanged

### Files

Backend: `alembic/versions/025_phase6_search_pin_prefs.py`, `app/main.py`, `app/config.py`, `app/models/{user,transcription}.py`, `app/schemas/{transcription,search}.py`, `app/routers/{search,transcriptions,users}.py`, `app/services/{notifications,queue,email}.py`

Frontend: `api/{search,notifications,transcriptions}.ts`, `types/index.ts`, `components/{AudioPlayer,NotificationsBell}.tsx`, `pages/{Settings,Transcriptions,TranscriptionDetail}.tsx`